### PR TITLE
Add C++ class for python constraints (ConstraintPython)

### DIFF
--- a/src/Mod/Fem/App/AppFem.cpp
+++ b/src/Mod/Fem/App/AppFem.cpp
@@ -148,6 +148,7 @@ PyMOD_INIT_FUNC(Fem)
     Fem::FemSetNodesObject          ::init();
 
     Fem::Constraint                 ::init();
+    Fem::ConstraintPython           ::init();
     Fem::ConstraintBearing          ::init();
     Fem::ConstraintFixed            ::init();
     Fem::ConstraintForce            ::init();

--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -54,6 +54,9 @@
 #include "FemConstraint.h"
 #include "FemTools.h"
 
+#include <App/DocumentObjectPy.h>
+#include <App/FeaturePythonPyImp.h>
+
 #include <Mod/Part/App/PartFeature.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
@@ -390,4 +393,28 @@ const Base::Vector3d Constraint::getDirection(const App::PropertyLinkSub &direct
     }
 
     return Fem::Tools::getDirectionFromShape(sh);
+}
+
+// Python feature ---------------------------------------------------------
+
+namespace App {
+/// @cond DOXERR
+PROPERTY_SOURCE_TEMPLATE(Fem::ConstraintPython, Fem::Constraint)
+template<> const char* Fem::ConstraintPython::getViewProviderName(void) const {
+    return "FemGui::ViewProviderFemConstraintPython";
+}
+
+template<> PyObject* Fem::ConstraintPython::getPyObject(void) {
+    if (PythonObject.is(Py::_None())) {
+        // ref counter is set to 1
+        PythonObject = Py::Object(new App::FeaturePythonPyT<App::DocumentObjectPy>(this),true);
+    }
+    return Py::new_reference_to(PythonObject);
+}
+
+// explicit template instantiation
+template class AppFemExport FeaturePythonT<Fem::Constraint>;
+
+/// @endcond
+
 }

--- a/src/Mod/Fem/App/FemConstraint.h
+++ b/src/Mod/Fem/App/FemConstraint.h
@@ -25,6 +25,7 @@
 #define FEM_CONSTRAINT_H
 
 #include <Base/Vector3D.h>
+#include <App/FeaturePython.h>
 #include <App/DocumentObject.h>
 #include <App/PropertyLinks.h>
 #include <App/PropertyGeo.h>
@@ -74,6 +75,9 @@ protected:
     const Base::Vector3d getDirection(const App::PropertyLinkSub &direction);
 
 };
+
+typedef App::FeaturePythonT<Constraint> ConstraintPython;
+
 
 } //namespace Fem
 

--- a/src/Mod/Fem/Gui/AppFemGui.cpp
+++ b/src/Mod/Fem/Gui/AppFemGui.cpp
@@ -120,6 +120,7 @@ PyMOD_INIT_FUNC(FemGui)
     FemGui::ViewProviderSetFaces                  ::init();
     FemGui::ViewProviderSetGeometry               ::init();
     FemGui::ViewProviderFemConstraint             ::init();
+    FemGui::ViewProviderFemConstraintPython       ::init();
     FemGui::ViewProviderFemConstraintBearing      ::init();
     FemGui::ViewProviderFemConstraintFixed        ::init();
     FemGui::ViewProviderFemConstraintForce        ::init();

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
@@ -490,3 +490,15 @@ void ViewProviderFemConstraint::checkForWizard()
         wizardSubLayout = wiz->findChild<QVBoxLayout*>(QString::fromLatin1("ShaftWizardLayout"));
     }
 }
+
+
+// Python feature -----------------------------------------------------------------------
+
+namespace Gui {
+/// @cond DOXERR
+PROPERTY_SOURCE_TEMPLATE(FemGui::ViewProviderFemConstraintPython, FemGui::ViewProviderFemConstraint)
+/// @endcond
+
+// explicit template instantiation
+template class FemGuiExport ViewProviderPythonFeatureT<ViewProviderFemConstraint>;
+}

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
@@ -25,6 +25,7 @@
 #define GUI_VIEWPROVIDERFEMCONSTRAINT_H
 
 #include <Gui/ViewProviderGeometryObject.h>
+#include <Gui/ViewProviderPythonFeature.h>
 #include <QObject>
 #include <QVBoxLayout>
 
@@ -116,6 +117,9 @@ protected:
     void checkForWizard();
     static QObject* findChildByName(const QObject* parent, const QString& name);
 };
+
+typedef Gui::ViewProviderPythonFeatureT<ViewProviderFemConstraint> ViewProviderFemConstraintPython;
+
 
 } //namespace FemGui
 

--- a/src/Mod/Fem/ObjectsFem.py
+++ b/src/Mod/Fem/ObjectsFem.py
@@ -112,7 +112,7 @@ def makeConstraintPulley(name="ConstraintPulley"):
 
 def makeConstraintSelfWeight(name="ConstraintSelfWeight"):
     '''makeConstraintSelfWeight([name]): creates an self weight object to define a gravity load'''
-    obj = FreeCAD.ActiveDocument.addObject("Fem::FeaturePython", name)
+    obj = FreeCAD.ActiveDocument.addObject("Fem::ConstraintPython", name)
     import PyObjects._FemConstraintSelfWeight
     PyObjects._FemConstraintSelfWeight._FemConstraintSelfWeight(obj)
     if FreeCAD.GuiUp:


### PR DESCRIPTION
Added to have a common base class for all constraints.This makes it easy to determine if the object is an constraint or not.