### PR TITLE
FEM: femtools/femutils.py typos and whitespace fixes

### DIFF
--- a/src/Mod/Fem/femtools/femutils.py
+++ b/src/Mod/Fem/femtools/femutils.py
@@ -106,7 +106,7 @@ def isDerivedFrom(obj, t):
 def getBoundBoxOfAllDocumentShapes(doc):
     overalboundbox = None
     for o in doc.Objects:
-        if hasattr(o, 'Shape') and hasattr(o.Shape, 'BoundBox'):  # netgen mesh obj has an attribut Shape which is a Document obj, which has no BB
+        if hasattr(o, 'Shape') and hasattr(o.Shape, 'BoundBox'):  # netgen mesh obj has an attribute Shape which is a Document obj, which has no BB
             try:
                 bb = o.Shape.BoundBox
             except:


### PR DESCRIPTION
Found via `codespell` 