### PR TITLE
FEM: Uniform file beginnings

### DIFF
--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraint.h
+++ b/src/Mod/Fem/App/FemConstraint.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintBearing.cpp
+++ b/src/Mod/Fem/App/FemConstraintBearing.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintBearing.h
+++ b/src/Mod/Fem/App/FemConstraintBearing.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintContact.cpp
+++ b/src/Mod/Fem/App/FemConstraintContact.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                      <jrheinlaender[at]users.sourceforge.net>           *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintContact.h
+++ b/src/Mod/Fem/App/FemConstraintContact.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintFixed.cpp
+++ b/src/Mod/Fem/App/FemConstraintFixed.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintFixed.h
+++ b/src/Mod/Fem/App/FemConstraintFixed.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintFluidBoundary.h
+++ b/src/Mod/Fem/App/FemConstraintFluidBoundary.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintForce.cpp
+++ b/src/Mod/Fem/App/FemConstraintForce.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintForce.h
+++ b/src/Mod/Fem/App/FemConstraintForce.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintGear.cpp
+++ b/src/Mod/Fem/App/FemConstraintGear.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintGear.h
+++ b/src/Mod/Fem/App/FemConstraintGear.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/App/FemConstraintPlaneRotation.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintPlaneRotation.h
+++ b/src/Mod/Fem/App/FemConstraintPlaneRotation.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintPulley.cpp
+++ b/src/Mod/Fem/App/FemConstraintPulley.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintPulley.h
+++ b/src/Mod/Fem/App/FemConstraintPulley.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintTransform.cpp
+++ b/src/Mod/Fem/App/FemConstraintTransform.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintTransform.h
+++ b/src/Mod/Fem/App/FemConstraintTransform.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemSolverObject.cpp
+++ b/src/Mod/Fem/App/FemSolverObject.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2013 J¨¹rgen Riegel (FreeCAD@juergen-riegel.net)        *
+ *   Copyright (c) 2013 Jürgen Riegel (FreeCAD@juergen-riegel.net)         *
  *   Copyright (c) 2015 Qingfeng Xia (FreeCAD@iesensor.com)                *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *

--- a/src/Mod/Fem/App/FemVTKTools.cpp
+++ b/src/Mod/Fem/App/FemVTKTools.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) Jürgen Riegel          (juergen.riegel@web.de) 2009     *
-  *   Copyright (c) Qingfeng Xia         (qingfeng.xia at oxford uni) 2017     *
+ *   Copyright (c) Jürgen Riegel        (juergen.riegel@web.de) 2009       *
+ *   Copyright (c) Qingfeng Xia         (qingfeng.xia at oxford uni) 2017  *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintBearing.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintBearing.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/InitGui.py
+++ b/src/Mod/Fem/InitGui.py
@@ -1,10 +1,3 @@
-# Fem gui init module
-# (c) 2009 Juergen Riegel
-#
-# Gathering all the information to start FreeCAD
-# This is the second one of three init scripts, the third one
-# runs when the gui is up
-
 #***************************************************************************
 #*   (c) Juergen Riegel (juergen.riegel@web.de) 2009                       *
 #*                                                                         *
@@ -28,6 +21,12 @@
 #*                                                                         *
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
+
+# Fem gui init module
+
+# Gathering all the information to start FreeCAD
+# This is the second one of three init scripts, the third one
+# runs when the gui is up
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/ObjectsFem.py
+++ b/src/Mod/Fem/ObjectsFem.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Objects FEM"
+__title__ = "FreeCAD FEM Objects"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/TestFem.py
+++ b/src/Mod/Fem/TestFem.py
@@ -23,6 +23,7 @@
 # *                                                                         *
 # ***************************************************************************/
 
+# Unit test for the FEM module
 
 # Unit test for the FEM module
 # the order should be as follows:

--- a/src/Mod/Fem/femcommands/commands.py
+++ b/src/Mod/Fem/femcommands/commands.py
@@ -20,6 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
+__title__ = "???"
+__author__ = "Bernd Hahnebach"
+__url__ = "http://www.freecadweb.org"
+
+## \addtogroup FEM
+#  @{
+
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femcommands/commands.py
+++ b/src/Mod/Fem/femcommands/commands.py
@@ -20,13 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "???"
+__title__ = "FreeCAD FEM Commands"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## \addtogroup FEM
 #  @{
-
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femcommands/manager.py
+++ b/src/Mod/Fem/femcommands/manager.py
@@ -21,7 +21,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Fem Commands"
+__title__ = "FreeCAD Fem Commands"
 __author__ = "Przemo Firszt"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femcommands/manager.py
+++ b/src/Mod/Fem/femcommands/manager.py
@@ -21,7 +21,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD Fem Commands"
+__title__ = "FreeCAD FEM Commands"
 __author__ = "Przemo Firszt"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femguiobjects/FemSelectionWidgets.py
+++ b/src/Mod/Fem/femguiobjects/FemSelectionWidgets.py
@@ -21,11 +21,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-
-__title__ = "FemSelectWidget"
+__title__ = "FreeCAD FEM FemSelectWidget"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## @package FemSelectWidget
+#  \ingroup FEM
+#  \brief FreeCAD FEM FemSelectWidget
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/ViewProviderFemConstraint.py
+++ b/src/Mod/Fem/femguiobjects/ViewProviderFemConstraint.py
@@ -21,11 +21,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-
-__title__ = "_Base ViewProvider"
+__title__ = "FreeCAD FEM _Base ViewProvider"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## @package _BaseViewProvider
+#  \ingroup FEM
+#  \brief FreeCAD _Base ViewProvider for FEM workbench
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_TaskPanelFemSolverControl.py
+++ b/src/Mod/Fem/femguiobjects/_TaskPanelFemSolverControl.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
-__title__ = "Solver Job Control Task Panel"
+__title__ = "FreeCAD FEM Solver Job Control Task Panel"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 from PySide import QtCore
 from PySide import QtGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintBodyHeatSource.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintBodyHeatSource.py
@@ -20,12 +20,14 @@
 # *                                                                         *
 # ***************************************************************************
 
-
-__title__ = "view provider for constraint body heat source object"
+__title__ = "FreeCAD FEM Vew Provider for Constraint Body Heat Source Object"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
+import FemConstraint
 from . import ViewProviderFemConstraint
 
 

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintBodyHeatSource.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintBodyHeatSource.py
@@ -27,7 +27,6 @@ __url__ = "http://www.freecadweb.org"
 ## \addtogroup FEM
 #  @{
 
-import FemConstraint
 from . import ViewProviderFemConstraint
 
 

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintElectrostaticPotential.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintElectrostaticPotential.py
@@ -20,11 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-
-__title__ = "view provider for constraint electrostatic potential object"
+__title__ = "FreeCAD FEM view provider for constraint electrostatic potential object"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## @package ViewProvider????
+#  \ingroup FEM
+#  \brief FreeCAD FEM view provider for constraint electrostatic potential object
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintFlowVelocity.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintFlowVelocity.py
@@ -20,11 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-
-__title__ = "view provider for constraint flow velocity object"
+__title__ = "FreeCAD FEM view provider for constraint flow velocity object"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## @package ViewProvider????
+#  \ingroup FEM
+#  \brief FreeCAD FEM view provider for constraint flow velocity object
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintInitialFlowVelocity.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintInitialFlowVelocity.py
@@ -20,11 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-
-__title__ = "view provider for constraint initial flow velocity object"
+__title__ = "FreeCAD FEM view provider for constraint initial flow velocity object"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## @package ViewProvider????
+#  \ingroup FEM
+#  \brief FreeCAD FEM view provider for constraint initial flow velocity object
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintSelfWeight.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintSelfWeight.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD FEM _ViewProviderFemConstraintSelfWeight"
+__title__ = "FreeCAD FEM Constraint SelfWeight ViewProvider"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemConstraintSelfWeight
 #  \ingroup FEM
-#  \brief FreeCAD FEM _ViewProviderFemConstraintSelfWeight
+#  \brief FreeCAD FEM Constraint SelfWeight ViewProvider
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintSelfWeight.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemConstraintSelfWeight.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemConstraintSelfWeight"
+__title__ = "FreeCAD FEM _ViewProviderFemConstraintSelfWeight"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemConstraintSelfWeight
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemConstraintSelfWeight
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemElementFluid1D.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemElementFluid1D.py
@@ -22,12 +22,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemElementFluid1D"
+__title__ = "FreeCAD FEM _ViewProviderFemElementFluid1D"
 __author__ = "Ofentse Kgoa, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemElementFluid1D
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemElementFluid1D
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemElementGeometry1D.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemElementGeometry1D.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemElementGeometry1D"
+__title__ = "FreeCAD FEM _ViewProviderFemElementGeometry1D"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemElementGeometry1D
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemElementGeometry1D
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemElementGeometry2D.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemElementGeometry2D.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemElementGeometry2D"
+__title__ = "FreeCAD FEM _ViewProviderFemElementGeometry2D"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemElementGeometry2D
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemElementGeometry2D
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemElementRotation1D.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemElementRotation1D.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemElementRotation1D"
+__title__ = "FreeCAD FEM _ViewProviderFemElementRotation1D"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemElementRotation1D
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemElementRotation1D
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemMaterial.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemMaterial.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemMaterial"
+__title__ = "FreeCAD FEM _ViewProviderFemMaterial"
 __author__ = "Juergen Riegel, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package _ViewProviderFemMaterial
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemMaterial
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemMaterialMechanicalNonlinear.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemMaterialMechanicalNonlinear.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemMaterialMechanicalNonlinear"
+__title__ = "FreeCAD FEM _ViewProviderFemMaterialMechanicalNonlinear"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemMaterialMechanicalNonLinear
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemMaterialMechanicalNonlinear
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshBoundaryLayer.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshBoundaryLayer.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemMeshBoundaryLayer"
+__title__ = "FreeCAD FEM _ViewProviderFemMeshBoundaryLayer"
 __author__ = "Bernd Hahnebach, Qingfeng Xia"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemMeshBoundaryLayer
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemMeshBoundaryLayer
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshGmsh.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshGmsh.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemMeshGmsh"
+__title__ = "FreeCAD FEM _ViewProviderFemMeshGmsh"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemMeshGmsh
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemMeshGmsh
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshGroup.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshGroup.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemMeshGroup"
+__title__ = "FreeCAD FEM _ViewProviderFemMeshGroup"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemMeshGroup
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemMeshGroup
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshRegion.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshRegion.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemMeshRegion"
+__title__ = "FreeCAD FEM _ViewProviderFemMeshRegion"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemMeshRegion
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemMeshRegion
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshResult.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshResult.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemMeshResult"
+__title__ = "FreeCAD FEM _ViewProviderFemMeshResult"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemMeshResult
 #  \ingroup FEM
-
+#  \brief FreeCAD FEM _ViewProviderFemMeshResult
 
 class _ViewProviderFemMeshResult:
     "A View Provider for the FemMeshResult object"

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemResultMechanical.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemResultMechanical.py
@@ -20,7 +20,7 @@
 #*                                                                         *
 #***************************************************************************
 
-__title__ = "ViewProvider for FEM mechanical ResultObjectPython"
+__title__ = "FreeCAD ViewProvider for FEM mechanical ResultObjectPython"
 __author__ = "Qingfeng Xia, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemSolverCalculix.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemSolverCalculix.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_ViewProviderFemSolverCalculix"
+__title__ = "FreeCAD FEM _ViewProviderFemSolverCalculix"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package ViewProviderFemSolverCalculix
 #  \ingroup FEM
+#  \brief FreeCAD FEM _ViewProviderFemSolverCalculix
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/Fem/femguiobjects/__init__.py
+++ b/src/Mod/Fem/femguiobjects/__init__.py
@@ -26,4 +26,4 @@ __url__ = "http://www.freecadweb.org"
 
 ## @package PyGui
 #  \ingroup Fem
-#  \brief Fem Gui module
+#  \brief FreeCAD FEM Gui modules

--- a/src/Mod/Fem/femguiobjects/__init__.py
+++ b/src/Mod/Fem/femguiobjects/__init__.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Fem Gui modules"
+__title__ = "FreeCAD FEM Gui modules"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/feminout/convert2TetGen.py
+++ b/src/Mod/Fem/feminout/convert2TetGen.py
@@ -1,12 +1,13 @@
 # (c) 2010 LGPL
 
+## \addtogroup FEM
+#  @{
+
+
 #Make mesh of pn junction in TetGen format
 import FreeCAD, FreeCADGui, Part, Mesh
 App = FreeCAD # shortcut
 Gui = FreeCADGui # shortcut
-
-## \addtogroup FEM
-#  @{
 
 def exportMeshToTetGenPoly(meshToExport,filePath,beVerbose=1):
     """Export mesh to TetGen *.poly file format"""

--- a/src/Mod/Fem/feminout/importCcxDatResults.py
+++ b/src/Mod/Fem/feminout/importCcxDatResults.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "importCcxDatResults"
+__title__ = "FreeCAD FEM importCcxDatResults"
 __author__ = "Przemo Firszt, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/feminout/importCcxFrdResults.py
+++ b/src/Mod/Fem/feminout/importCcxFrdResults.py
@@ -22,7 +22,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD Calculix library"
+__title__ = "FreeCAD FEM Calculix library"
 __author__ = "Juergen Riegel , Michael Hindley, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/feminout/importFenicsMesh.py
+++ b/src/Mod/Fem/feminout/importFenicsMesh.py
@@ -19,7 +19,6 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-from __future__ import print_function
 
 __title__ = "FreeCAD Fenics mesh reader and writer"
 __author__ = "Johannes Hartung"
@@ -28,6 +27,8 @@ __url__ = "http://www.freecadweb.org"
 ## @package importFenicsMesh
 #  \ingroup FEM
 #  \brief FreeCAD Fenics Mesh reader and writer for FEM workbench
+
+from __future__ import print_function
 
 from PySide import QtGui, QtCore
 

--- a/src/Mod/Fem/feminout/importFenicsMesh.py
+++ b/src/Mod/Fem/feminout/importFenicsMesh.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD Fenics mesh reader and writer"
+__title__ = "FreeCAD FEM Fenics mesh reader and writer"
 __author__ = "Johannes Hartung"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/feminout/importVTKResults.py
+++ b/src/Mod/Fem/feminout/importVTKResults.py
@@ -1,4 +1,6 @@
 # ***************************************************************************
+# *   Copyright (c) Jürgen Riegel       (juergen.riegel@web.de) 2002        *
+# *   Copyright (c) Qingfeng Xia        (qingfeng.xia at oxford uni) 2017   *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -18,8 +20,6 @@
 # *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
 # *   USA                                                                   *
 # *                                                                         *
-# *   Juergen Riegel 2002                                                   *
-# *   (c) Qingfeng Xia 2017                                                 *
 # ***************************************************************************/
 
 __title__ = "FreeCAD FEM Result import and export VTK file library"

--- a/src/Mod/Fem/feminout/importVTKResults.py
+++ b/src/Mod/Fem/feminout/importVTKResults.py
@@ -22,13 +22,13 @@
 # *   (c) Qingfeng Xia 2017                                                 *
 # ***************************************************************************/
 
-__title__ = "FreeCAD Result import and export VTK file library"
+__title__ = "FreeCAD FEM Result import and export VTK file library"
 __author__ = "Qingfeng Xia, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package importVTKResults
 #  \ingroup FEM
-#  \brief FreeCAD Result import and export VTK file library
+#  \brief FreeCAD FEM Result import and export VTK file library
 
 import os
 import FreeCAD

--- a/src/Mod/Fem/feminout/importVTKResults.py
+++ b/src/Mod/Fem/feminout/importVTKResults.py
@@ -1,5 +1,4 @@
 # ***************************************************************************
-# *   (c) Qingfeng Xia 2017                       *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -20,6 +19,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # *   Juergen Riegel 2002                                                   *
+# *   (c) Qingfeng Xia 2017                                                 *
 # ***************************************************************************/
 
 __title__ = "FreeCAD Result import and export VTK file library"

--- a/src/Mod/Fem/feminout/importZ88Mesh.py
+++ b/src/Mod/Fem/feminout/importZ88Mesh.py
@@ -19,15 +19,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-from __future__ import print_function
 
-__title__ = "FreeCAD Z88 Mesh reader and writer"
+__title__ = "FreeCAD FEM Z88 Mesh reader and writer"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package importZ88Mesh
 #  \ingroup FEM
 #  \brief FreeCAD Z88 Mesh reader and writer for FEM workbench
+
+from __future__ import print_function
 
 import FreeCAD
 import os

--- a/src/Mod/Fem/feminout/importZ88O2Results.py
+++ b/src/Mod/Fem/feminout/importZ88O2Results.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD Z88 Disp Reader"
+__title__ = "FreeCAD FEM Z88 Disp Reader"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package importZ88O2Results
 #  \ingroup FEM
-#  \brief FreeCAD Z88 Disp Reader for FEM workbench
+#  \brief FreeCAD FEM Z88 Disp Reader for FEM workbench
 
 import FreeCAD
 import os

--- a/src/Mod/Fem/feminout/readFenicsXDMF.py
+++ b/src/Mod/Fem/feminout/readFenicsXDMF.py
@@ -19,7 +19,6 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-from __future__ import print_function
 
 __title__ = "FreeCAD FEM Fenics XDMF mesh reader"
 __author__ = "Johannes Hartung"
@@ -29,6 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 #  \brief FreeCAD Fenics Mesh XDMF reader for FEM workbench
 
+from __future__ import print_function
 
 def read_fenics_mesh_xdmf(xdmffilename):
 

--- a/src/Mod/Fem/feminout/readFenicsXDMF.py
+++ b/src/Mod/Fem/feminout/readFenicsXDMF.py
@@ -21,7 +21,7 @@
 # ***************************************************************************
 from __future__ import print_function
 
-__title__ = "FreeCAD Fenics XDMF mesh reader"
+__title__ = "FreeCAD FEM Fenics XDMF mesh reader"
 __author__ = "Johannes Hartung"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/feminout/readFenicsXML.py
+++ b/src/Mod/Fem/feminout/readFenicsXML.py
@@ -19,9 +19,8 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-from __future__ import print_function
 
-__title__ = "FreeCAD Fenics XML mesh reader"
+__title__ = "FreeCAD FEM Fenics Solver XML Mesh Reader"
 __author__ = "Johannes Hartung"
 __url__ = "http://www.freecadweb.org"
 
@@ -29,6 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 #  \brief FreeCAD Fenics Mesh XML reader for FEM workbench
 
+from __future__ import print_function
 
 import FreeCAD
 from xml.etree import ElementTree as ET

--- a/src/Mod/Fem/feminout/writeFenicsXDMF.py
+++ b/src/Mod/Fem/feminout/writeFenicsXDMF.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD Fenics XDMF mesh writer"
+__title__ = "FreeCAD FEM Fenics XDMF mesh writer"
 __author__ = "Johannes Hartung"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/feminout/writeFenicsXDMF.py
+++ b/src/Mod/Fem/feminout/writeFenicsXDMF.py
@@ -19,6 +19,15 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+
+__title__ = "FreeCAD Fenics XDMF mesh writer"
+__author__ = "Johannes Hartung"
+__url__ = "http://www.freecadweb.org"
+
+## @package exportFenicsXDMF
+#  \ingroup FEM
+#  \brief FreeCAD Fenics Mesh XDMF writer for FEM workbench
+
 from __future__ import print_function
 
 from .importToolsFem import \
@@ -30,14 +39,6 @@ from .importToolsFem import \
 from xml.etree import ElementTree as ET  # parsing xml files and exporting
 import numpy as np
 
-
-__title__ = "FreeCAD Fenics XDMF mesh writer"
-__author__ = "Johannes Hartung"
-__url__ = "http://www.freecadweb.org"
-
-## @package exportFenicsXDMF
-#  \ingroup FEM
-#  \brief FreeCAD Fenics Mesh XDMF writer for FEM workbench
 
 ENCODING_ASCII = 'ASCII'
 ENCODING_HDF5 = 'HDF5'

--- a/src/Mod/Fem/feminout/writeFenicsXML.py
+++ b/src/Mod/Fem/feminout/writeFenicsXML.py
@@ -21,7 +21,7 @@
 # ***************************************************************************
 from __future__ import print_function
 
-__title__ = "FreeCAD Fenics XML mesh writer"
+__title__ = "FreeCAD FEM Fenics XML mesh writer"
 __author__ = "Johannes Hartung"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femmesh/femmesh2mesh.py
+++ b/src/Mod/Fem/femmesh/femmesh2mesh.py
@@ -20,14 +20,14 @@
 # *                                                                         *
 # ***************************************************************************
 
-from __future__ import print_function
-
 __title__ = "FemMesh to Mesh converter"
 __author__ = "Frantisek Loeffelmann, Ulrich Brammer, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FwmMesh2Mesh
 #  \ingroup FEM
+
+from __future__ import print_function
 
 import time
 # import Mesh

--- a/src/Mod/Fem/femmesh/femmesh2mesh.py
+++ b/src/Mod/Fem/femmesh/femmesh2mesh.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FemMesh to Mesh converter"
+__title__ = "FreeCAD FEM FemMesh to Mesh converter"
 __author__ = "Frantisek Loeffelmann, Ulrich Brammer, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FwmMesh2Mesh
 #  \ingroup FEM
+#  \brief FreeCAD FEM FemMesh to Mesh converter
 
 from __future__ import print_function
 

--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Tools for the work with Gmsh mesher"
+__title__ = "FreeCAD FEM Tools for working with Gmsh mesher"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femmesh/meshtools.py
+++ b/src/Mod/Fem/femmesh/meshtools.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Tools for the work with FEM meshes"
+__title__ = "FreeCAD FEM Tools for working with FEM meshes"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femobjects/FemConstraint.py
+++ b/src/Mod/Fem/femobjects/FemConstraint.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "FreeCAD FEM _Base"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 class Proxy(object):
 

--- a/src/Mod/Fem/femobjects/FemConstraint.py
+++ b/src/Mod/Fem/femobjects/FemConstraint.py
@@ -21,7 +21,7 @@
 # ***************************************************************************
 
 
-__title__ = "_Base"
+__title__ = "FreeCAD FEM _Base"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femobjects/FemConstraint.py
+++ b/src/Mod/Fem/femobjects/FemConstraint.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD FEM _Base"
+__title__ = "FreeCAD FEM base constraint"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femobjects/_FemConstraintBodyHeatSource.py
+++ b/src/Mod/Fem/femobjects/_FemConstraintBodyHeatSource.py
@@ -20,11 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-
-__title__ = "the constraint body heat source object"
+__title__ = "FreeCAD FEM constraint body heat source object"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## @package FemConstraintBodyHeatSource
+#  \ingroup FEM
+#  \brief FreeCAD FEM constraint body heat source object
 
 from . import FemConstraint
 

--- a/src/Mod/Fem/femobjects/_FemConstraintElectrostaticPotential.py
+++ b/src/Mod/Fem/femobjects/_FemConstraintElectrostaticPotential.py
@@ -20,11 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-
-__title__ = "the constraint electrostatic potential object"
+__title__ = "FreeCAD FEM constraint electrostatic potential object"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## @package FemConstraintElectrostaticPotential
+#  \ingroup FEM
+#  \brief FreeCAD FEM constraint electrostatic potential object
 
 from . import FemConstraint
 

--- a/src/Mod/Fem/femobjects/_FemConstraintFlowVelocity.py
+++ b/src/Mod/Fem/femobjects/_FemConstraintFlowVelocity.py
@@ -20,7 +20,6 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "the constraint flow velocity object"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"

--- a/src/Mod/Fem/femobjects/_FemConstraintFlowVelocity.py
+++ b/src/Mod/Fem/femobjects/_FemConstraintFlowVelocity.py
@@ -20,10 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "the constraint flow velocity object"
+__title__ = "FreeCAD FEM constraint flow velocity object"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## @package FemConstraintFlowVelocity
+#  \ingroup FEM
+#  \brief FreeCAD FEM constraint flow velocity object
 
 from . import FemConstraint
 

--- a/src/Mod/Fem/femobjects/_FemConstraintInitialFlowVelocity.py
+++ b/src/Mod/Fem/femobjects/_FemConstraintInitialFlowVelocity.py
@@ -20,7 +20,6 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "the constraint initial flow velocity object"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"

--- a/src/Mod/Fem/femobjects/_FemConstraintInitialFlowVelocity.py
+++ b/src/Mod/Fem/femobjects/_FemConstraintInitialFlowVelocity.py
@@ -20,9 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "the constraint initial flow velocity object"
+__title__ = "FreeCAD FEM constraint initial flow velocity object"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
+
+## @package FemConstraintInitialFlowVelocity
+#  \ingroup FEM
+#  \brief FreeCAD FEM constraint initial flow velocity object
 
 
 from . import FemConstraint

--- a/src/Mod/Fem/femobjects/_FemConstraintSelfWeight.py
+++ b/src/Mod/Fem/femobjects/_FemConstraintSelfWeight.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "the constraint self weight object"
+__title__ = "FreeCAD FEM constraint self weight object"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemConstraintSelfWeight
 #  \ingroup FEM
-
+#  \bried FreeCAD FEM constraint self weight object
 
 class _FemConstraintSelfWeight:
     "The FemConstraintSelfWeight object"

--- a/src/Mod/Fem/femobjects/_FemElementFluid1D.py
+++ b/src/Mod/Fem/femobjects/_FemElementFluid1D.py
@@ -21,13 +21,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_FemElementFluid1D"
+__title__ = "FreeCAD FEM _FemElementFluid1D"
 __author__ = "Ofentse Kgoa"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemElementFluid1D
 #  \ingroup FEM
-
+#  \brief FreeCAD FEM _FemElementFluid1D
 
 class _FemElementFluid1D:
     "The FemElementFluid1D object"

--- a/src/Mod/Fem/femobjects/_FemElementGeometry1D.py
+++ b/src/Mod/Fem/femobjects/_FemElementGeometry1D.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD FEM FemElementGeometry1D"
+__title__ = "FreeCAD FEM element geometry 1D object"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemElementGeometry1D
 #  \ingroup FEM
-#  \brief FreeCAD FEM FemElementGeometry1D
+#  \brief FreeCAD FEM element geometry 1D object
 
 class _FemElementGeometry1D:
     "The FemElementGeometry1D object"

--- a/src/Mod/Fem/femobjects/_FemElementGeometry1D.py
+++ b/src/Mod/Fem/femobjects/_FemElementGeometry1D.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FemElementGeometry1D"
+__title__ = "FreeCAD FEM FemElementGeometry1D"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemElementGeometry1D
 #  \ingroup FEM
-
+#  \brief FreeCAD FEM FemElementGeometry1D
 
 class _FemElementGeometry1D:
     "The FemElementGeometry1D object"

--- a/src/Mod/Fem/femobjects/_FemElementGeometry2D.py
+++ b/src/Mod/Fem/femobjects/_FemElementGeometry2D.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_FemElementGeometry2D"
+__title__ = "FreeCAD FEM _FemElementGeometry2D"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemElementGeometry2D
 #  \ingroup FEM
-
+#  \brief FreeCAD FEM _FemElementGeometry2D
 
 class _FemElementGeometry2D:
     "The FemElementGeometry2D object"

--- a/src/Mod/Fem/femobjects/_FemElementGeometry2D.py
+++ b/src/Mod/Fem/femobjects/_FemElementGeometry2D.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD FEM _FemElementGeometry2D"
+__title__ = "FreeCAD FEM element geometry 2D object"
 __author__ = "Bernd Hahnebach"
-__url__ = "http://www.freecadweb.org"
+__url__ = "https://www.freecadweb.org"
 
 ## @package FemElementGeometry2D
 #  \ingroup FEM
-#  \brief FreeCAD FEM _FemElementGeometry2D
+#  \brief FreeCAD FEM element geometry 2D object
 
 class _FemElementGeometry2D:
     "The FemElementGeometry2D object"

--- a/src/Mod/Fem/femobjects/_FemElementRotation1D.py
+++ b/src/Mod/Fem/femobjects/_FemElementRotation1D.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD FEM FemElementRotation1D"
+__title__ = "FreeCAD FEM element rotation 1D object"
 __author__ = "Bernd Hahnebach"
-__url__ = "http://www.freecadweb.org"
+__url__ = "https://www.freecadweb.org"
 
 ## @package FemElementRotation1D
 #  \ingroup FEM
-#  \brief FreeCAD FEM FemElementRotation1D
+#  \brief FreeCAD FEM element rotation 1D object
 
 class _FemElementRotation1D:
     "The FemElementRotation1D object"

--- a/src/Mod/Fem/femobjects/_FemElementRotation1D.py
+++ b/src/Mod/Fem/femobjects/_FemElementRotation1D.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FemElementRotation1D"
+__title__ = "FreeCAD FEM FemElementRotation1D"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemElementRotation1D
 #  \ingroup FEM
-
+#  \brief FreeCAD FEM FemElementRotation1D
 
 class _FemElementRotation1D:
     "The FemElementRotation1D object"

--- a/src/Mod/Fem/femobjects/_FemMaterial.py
+++ b/src/Mod/Fem/femobjects/_FemMaterial.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FemMaterial"
+__title__ = "FreeCAD FEM FemMaterial"
 __author__ = "Juergen Riegel, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemMaterial
 #  \ingroup FEM
-
+#  \brief FemMaterial
 
 class _FemMaterial:
     "The FEM Material object"

--- a/src/Mod/Fem/femobjects/_FemMaterial.py
+++ b/src/Mod/Fem/femobjects/_FemMaterial.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD FEM FemMaterial"
+__title__ = "FreeCAD FEM material"
 __author__ = "Juergen Riegel, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femobjects/_FemMaterial.py
+++ b/src/Mod/Fem/femobjects/_FemMaterial.py
@@ -26,7 +26,7 @@ __url__ = "http://www.freecadweb.org"
 
 ## @package FemMaterial
 #  \ingroup FEM
-#  \brief FemMaterial
+#  \brief FEM material
 
 class _FemMaterial:
     "The FEM Material object"

--- a/src/Mod/Fem/femobjects/_FemMaterialMechanicalNonlinear.py
+++ b/src/Mod/Fem/femobjects/_FemMaterialMechanicalNonlinear.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "the fem nonlinear mechanical material object"
+__title__ = "FreeCAD FEM Nonlinear Mechanical Material Object"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemMaterialMechanicalNonLinear
 #  \ingroup FEM
+#  \brief FreeCAD FEM Nonlinear Mechanical Material Object for FEM workbench
 
 
 class _FemMaterialMechanicalNonlinear:

--- a/src/Mod/Fem/femobjects/_FemMaterialMechanicalNonlinear.py
+++ b/src/Mod/Fem/femobjects/_FemMaterialMechanicalNonlinear.py
@@ -26,7 +26,7 @@ __url__ = "http://www.freecadweb.org"
 
 ## @package FemMaterialMechanicalNonLinear
 #  \ingroup FEM
-#  \brief FreeCAD FEM Nonlinear Mechanical Material Object for FEM workbench
+#  \brief FEM nonlinear mechanical material object
 
 class _FemMaterialMechanicalNonlinear:
     "The FemMaterialMechanicalNonlinear object"

--- a/src/Mod/Fem/femobjects/_FemMaterialMechanicalNonlinear.py
+++ b/src/Mod/Fem/femobjects/_FemMaterialMechanicalNonlinear.py
@@ -28,7 +28,6 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 #  \brief FreeCAD FEM Nonlinear Mechanical Material Object for FEM workbench
 
-
 class _FemMaterialMechanicalNonlinear:
     "The FemMaterialMechanicalNonlinear object"
     def __init__(self, obj):

--- a/src/Mod/Fem/femobjects/_FemMeshBoundaryLayer.py
+++ b/src/Mod/Fem/femobjects/_FemMeshBoundaryLayer.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FreeCAD FEM _FemMeshBoundaryLayer"
+__title__ = "FreeCAD FEM mesh boundary layer object"
 __author__ = "Bernd Hahnebach, Qingfeng Xia"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemMeshBoundaryLayer
 #  \ingroup FEM
-#  \brief _FemMeshBoundaryLayer
+#  \brief FEM mesh boundary layer object
 
 class _FemMeshBoundaryLayer:
     "The FemMeshBoundaryLayer object"

--- a/src/Mod/Fem/femobjects/_FemMeshBoundaryLayer.py
+++ b/src/Mod/Fem/femobjects/_FemMeshBoundaryLayer.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_FemMeshBoundaryLayer"
+__title__ = "FreeCAD FEM _FemMeshBoundaryLayer"
 __author__ = "Bernd Hahnebach, Qingfeng Xia"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemMeshBoundaryLayer
 #  \ingroup FEM
-
+#  \brief _FemMeshBoundaryLayer
 
 class _FemMeshBoundaryLayer:
     "The FemMeshBoundaryLayer object"

--- a/src/Mod/Fem/femobjects/_FemMeshGmsh.py
+++ b/src/Mod/Fem/femobjects/_FemMeshGmsh.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_FemMeshGmsh"
+__title__ = "FreeCAD FEM _FemMeshGmsh"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemMeshGmsh
 #  \ingroup FEM
-
+#  \brief FreeCAD FEM _FemMeshGmsh
 
 class _FemMeshGmsh():
     """A Fem::FemMeshObject python type, add Gmsh specific properties

--- a/src/Mod/Fem/femobjects/_FemMeshGroup.py
+++ b/src/Mod/Fem/femobjects/_FemMeshGroup.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_FemMeshGroup"
+__title__ = "FreeCAD FEM _FemMeshGroup"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemMeshGroup
 #  \ingroup FEM
-
+#  \brief FreeCAD FEM _FemMeshGroup
 
 class _FemMeshGroup:
     "The FemMeshGroup object"

--- a/src/Mod/Fem/femobjects/_FemMeshRegion.py
+++ b/src/Mod/Fem/femobjects/_FemMeshRegion.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_FemMeshRegion"
+__title__ = "FreeCAD FEM _FemMeshRegion"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemMeshRegion
 #  \ingroup FEM
-
+#  \brief FreeCAD FEM _FemMeshRegion
 
 class _FemMeshRegion:
     "The FemMeshRegion object"

--- a/src/Mod/Fem/femobjects/_FemMeshResult.py
+++ b/src/Mod/Fem/femobjects/_FemMeshResult.py
@@ -20,13 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_FemMeshResult"
+__title__ = "FreeCAD FEM _FemMeshResult"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemMeshResult
 #  \ingroup FEM
-
+#  \brief FreeCAD FEM _FemMeshResult
 
 class _FemMeshResult():
     """The Fem::FemMeshObject's Proxy python type, add Result specific object type

--- a/src/Mod/Fem/femobjects/_FemResultMechanical.py
+++ b/src/Mod/Fem/femobjects/_FemResultMechanical.py
@@ -20,14 +20,13 @@
 #*                                                                         *
 #***************************************************************************
 
-__title__ = "DocumentOject Class to hold mechanical FEM results"
+__title__ = "FreeCAD DocumentOject Class to hold mechanical FEM results"
 __author__ = "Qingfeng Xia, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemResultMechanical
 #  \ingroup FEM
 #  \brief FreeCAD DocumentObject class to hold mechanical results in FEM workbench
-
 
 class _FemResultMechanical():
     """The Fem::_FemResultMechanical's Proxy python type, add result specific properties

--- a/src/Mod/Fem/femobjects/_FemSolverCalculix.py
+++ b/src/Mod/Fem/femobjects/_FemSolverCalculix.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_FemSolverCalculix"
+__title__ = "FreeCAD FEM _FemSolverCalculix"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package FemSolverCalculix
 #  \ingroup FEM
+#  \brief FreeCAD FEM _FemSolverCalculix
 
 import FreeCAD
 from femtools import ccxtools

--- a/src/Mod/Fem/femobjects/__init__.py
+++ b/src/Mod/Fem/femobjects/__init__.py
@@ -20,10 +20,10 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Fem Gui modules"
+__title__ = "FreeCAD FEM Gui modules"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package PyGui
 #  \ingroup Fem
-#  \brief Fem Gui module
+#  \brief FreeCAD FEM Gui modules

--- a/src/Mod/Fem/femresult/resulttools.py
+++ b/src/Mod/Fem/femresult/resulttools.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Fem Tools for results"
+__title__ = "FreeCAD FEM Tools for results"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/calculix/solver.py
+++ b/src/Mod/Fem/femsolver/calculix/solver.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "CalculiX SolverObject"
+__title__ = "FreeCAD FEM CalculiX SolverObject"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/calculix/tasks.py
+++ b/src/Mod/Fem/femsolver/calculix/tasks.py
@@ -21,7 +21,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "CalculiX Tasks"
+__title__ = "FreeCAD FEM CalculiX Tasks"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/calculix/tasks.py
+++ b/src/Mod/Fem/femsolver/calculix/tasks.py
@@ -21,11 +21,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "CalculiX Tasks"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import os
 import subprocess

--- a/src/Mod/Fem/femsolver/calculix/writer.py
+++ b/src/Mod/Fem/femsolver/calculix/writer.py
@@ -21,7 +21,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "CalculiX Writer"
+__title__ = "FreeCAD FEM CalculiX Writer"
 __author__ = "Przemo Firszt, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/equations/elasticity.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/elasticity.py
@@ -24,6 +24,8 @@ __title__ = "FreeCAD FEM Elmer Solver Elasticity"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import femtools.femutils as FemUtils
 from ... import equationbase

--- a/src/Mod/Fem/femsolver/elmer/equations/elasticity.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/elasticity.py
@@ -20,8 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-
-__title__ = "Elasticity"
+__title__ = "FreeCAD FEM Elmer Solver Elasticity"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/equations/electrostatic.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/electrostatic.py
@@ -20,8 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-
-__title__ = "Electrostatic"
+__title__ = "FreeCAD FEM Elmer Solver Electrostatic"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/equations/electrostatic.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/electrostatic.py
@@ -24,6 +24,8 @@ __title__ = "FreeCAD FEM Elmer Solver Electrostatic"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import femtools.femutils as FemUtils
 from ... import equationbase

--- a/src/Mod/Fem/femsolver/elmer/equations/equation.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/equation.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "Equation"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import FreeCAD as App
 from ... import equationbase

--- a/src/Mod/Fem/femsolver/elmer/equations/equation.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/equation.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Equation"
+__title__ = "FreeCAD FEM Equation"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/equations/flow.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/flow.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Flow"
+__title__ = "FreeCAD FEM Flow"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/equations/flow.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/flow.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "Flow"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import femtools.femutils as FemUtils
 from . import nonlinear

--- a/src/Mod/Fem/femsolver/elmer/equations/fluxsolver.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/fluxsolver.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "Fluxsolver"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import femtools.femutils as FemUtils
 from ... import equationbase

--- a/src/Mod/Fem/femsolver/elmer/equations/fluxsolver.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/fluxsolver.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Fluxsolver"
+__title__ = "FreeCAD FEM Fluxsolver"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/equations/heat.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/heat.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "Heat"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import femtools.femutils as FemUtils
 from . import nonlinear

--- a/src/Mod/Fem/femsolver/elmer/equations/heat.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/heat.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Heat"
+__title__ = "FreeCAD FEM Heat"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/equations/linear.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/linear.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_Linear"
+__title__ = "FreeCAD FEM _Linear"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/equations/linear.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/linear.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "_Linear"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 from . import equation
 

--- a/src/Mod/Fem/femsolver/elmer/equations/nonlinear.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/nonlinear.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_NonLinear"
+__title__ = "FreeCAD FEM _NonLinear"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/equations/nonlinear.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/nonlinear.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "_NonLinear"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 from . import linear
 

--- a/src/Mod/Fem/femsolver/elmer/sifio.py
+++ b/src/Mod/Fem/femsolver/elmer/sifio.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "???"
+__title__ = "FreeCAD FEM ???"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/sifio.py
+++ b/src/Mod/Fem/femsolver/elmer/sifio.py
@@ -20,6 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
+__title__ = "???"
+__author__ = "Markus Hovorka"
+__url__ = "http://www.freecadweb.org"
+
+## \addtogroup FEM
+#  @{
 
 import collections
 import six

--- a/src/Mod/Fem/femsolver/elmer/solver.py
+++ b/src/Mod/Fem/femsolver/elmer/solver.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "Elmer"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import femtools.femutils as FemUtils
 

--- a/src/Mod/Fem/femsolver/elmer/solver.py
+++ b/src/Mod/Fem/femsolver/elmer/solver.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Elmer"
+__title__ = "FreeCAD FEM FreeCAD FEM Elmer"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/tasks.py
+++ b/src/Mod/Fem/femsolver/elmer/tasks.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "FemElmerTasks"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import subprocess
 import os.path

--- a/src/Mod/Fem/femsolver/elmer/tasks.py
+++ b/src/Mod/Fem/femsolver/elmer/tasks.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FemElmerTasks"
+__title__ = "FreeCAD FEM FemElmerTasks"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FemWriterElmer"
+__title__ = "FreeCAD FEM FemWriterElmer"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "FemWriterElmer"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import os
 import os.path

--- a/src/Mod/Fem/femsolver/equationbase.py
+++ b/src/Mod/Fem/femsolver/equationbase.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "_Base"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import FreeCAD
 if FreeCAD.GuiUp:

--- a/src/Mod/Fem/femsolver/equationbase.py
+++ b/src/Mod/Fem/femsolver/equationbase.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "_Base"
+__title__ = "FreeCAD FEM _Base"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/report.py
+++ b/src/Mod/Fem/femsolver/report.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "report"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import FreeCAD as App
 

--- a/src/Mod/Fem/femsolver/report.py
+++ b/src/Mod/Fem/femsolver/report.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "report"
+__title__ = "FreeCAD FEM report"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/reportdialog.py
+++ b/src/Mod/Fem/femsolver/reportdialog.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "reportdialog"
+__title__ = "FreeCAD FEM reportdialog"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/reportdialog.py
+++ b/src/Mod/Fem/femsolver/reportdialog.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "reportdialog"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 from PySide import QtGui
 

--- a/src/Mod/Fem/femsolver/run.py
+++ b/src/Mod/Fem/femsolver/run.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "run"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import os
 import os.path

--- a/src/Mod/Fem/femsolver/run.py
+++ b/src/Mod/Fem/femsolver/run.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "run"
+__title__ = "FreeCAD FEM run"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/settings.py
+++ b/src/Mod/Fem/femsolver/settings.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "settings"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import distutils.spawn
 import FreeCAD as App

--- a/src/Mod/Fem/femsolver/settings.py
+++ b/src/Mod/Fem/femsolver/settings.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "settings"
+__title__ = "FreeCAD FEM settings"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/signal.py
+++ b/src/Mod/Fem/femsolver/signal.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "signal"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 def notify(signal, *args):
     for slot in signal:

--- a/src/Mod/Fem/femsolver/signal.py
+++ b/src/Mod/Fem/femsolver/signal.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "signal"
+__title__ = "FreeCAD FEM signal"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/solverbase.py
+++ b/src/Mod/Fem/femsolver/solverbase.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "General Solver Object"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 from PySide import QtGui
 

--- a/src/Mod/Fem/femsolver/solverbase.py
+++ b/src/Mod/Fem/femsolver/solverbase.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "General Solver Object"
+__title__ = "FreeCAD FEM General Solver Object"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/task.py
+++ b/src/Mod/Fem/femsolver/task.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "task"
+__title__ = "FreeCAD FEM task"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/task.py
+++ b/src/Mod/Fem/femsolver/task.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "task"
 __author__ = "Markus Hovorka"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import threading
 import time

--- a/src/Mod/Fem/femsolver/writerbase.py
+++ b/src/Mod/Fem/femsolver/writerbase.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FemInputWriter"
+__title__ = "FreeCAD FEM FemInputWriter"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/z88/solver.py
+++ b/src/Mod/Fem/femsolver/z88/solver.py
@@ -20,12 +20,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Z88 SolverObject"
+__title__ = "FreeCAD FEM Z88 SolverObject"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package SolverZ88
 #  \ingroup FEM
+#  \brief FreeCAD FEM Z88 SolverObject
 
 import os
 import glob

--- a/src/Mod/Fem/femsolver/z88/tasks.py
+++ b/src/Mod/Fem/femsolver/z88/tasks.py
@@ -20,11 +20,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-
 __title__ = "Z88 Tasks"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import os
 import subprocess

--- a/src/Mod/Fem/femsolver/z88/tasks.py
+++ b/src/Mod/Fem/femsolver/z88/tasks.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Z88 Tasks"
+__title__ = "FreeCAD FEM Z88 Tasks"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femsolver/z88/writer.py
+++ b/src/Mod/Fem/femsolver/z88/writer.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Z88 Writer"
+__title__ = "FreeCAD FEM Z88 Writer"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femtest/testfiles/__init__.py
+++ b/src/Mod/Fem/femtest/testfiles/__init__.py
@@ -20,10 +20,10 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Fem test cases"
+__title__ = "FreeCAD FEM test cases"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
 ## @package test_files
 #  \ingroup Fem
-#  \brief Fem test cases
+#  \brief FreeCAD FEM test cases

--- a/src/Mod/Fem/femtest/testfiles/ccx/__init__.py
+++ b/src/Mod/Fem/femtest/testfiles/ccx/__init__.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Fem ccx test cases"
+__title__ = "FreeCAD FEM ccx test cases"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femtest/testfiles/elmer/__init__.py
+++ b/src/Mod/Fem/femtest/testfiles/elmer/__init__.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Fem ccx test cases"
+__title__ = "FreeCAD FEM ccx test cases"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femtest/testfiles/mesh/__init__.py
+++ b/src/Mod/Fem/femtest/testfiles/mesh/__init__.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "Fem test cases"
+__title__ = "FreeCAD FEM test cases"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femtest/testtools.py
+++ b/src/Mod/Fem/femtest/testtools.py
@@ -22,10 +22,13 @@
 # *                                                                         *
 # ***************************************************************************/
 
-__title__ = "Tools for FEM unit tests"
+__title__ = "FreeCAD Tools for FEM unit tests"
 __author__ = "Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## @package testtools
+#  \ingroup Fem
+#  \brief FreeCAD Tools for FEM unit tests
 
 import FreeCAD
 import tempfile

--- a/src/Mod/Fem/femtools/ccxtools.py
+++ b/src/Mod/Fem/femtools/ccxtools.py
@@ -21,7 +21,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-__title__ = "FemToolsCcx"
+__title__ = "FreeCAD FEM CalculiX Solver FemToolsCcx"
 __author__ = "Przemo Firszt, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 

--- a/src/Mod/Fem/femtools/femutils.py
+++ b/src/Mod/Fem/femtools/femutils.py
@@ -26,6 +26,8 @@ __title__ = "FEM Utilities"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 
+## \addtogroup FEM
+#  @{
 
 import FreeCAD
 import FreeCAD as App

--- a/src/Mod/Fem/femtools/femutils.py
+++ b/src/Mod/Fem/femtools/femutils.py
@@ -22,7 +22,7 @@
 # ***************************************************************************
 
 
-__title__ = "FEM Utilities"
+__title__ = "FreeCAD FEM Utilities"
 __author__ = "Markus Hovorka, Bernd Hahnebach"
 __url__ = "http://www.freecadweb.org"
 


### PR DESCRIPTION
4 main fixes occur in this PR:   
1.  Every `__title__=` has `FreeCAD FEM` prepended to it  
2.  any python `import` or `from` directives are moved below `__title__=` and doxygen blocks  
3.  doxygen blocks are added to files that didn't have them  
4.  `\brief` is added to files that didn't have it  
5.  whitespace fixes  