### PR TITLE
FEM: fix .cpp and .h header text

### DIFF
--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraint.h
+++ b/src/Mod/Fem/App/FemConstraint.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintBearing.cpp
+++ b/src/Mod/Fem/App/FemConstraintBearing.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintBearing.h
+++ b/src/Mod/Fem/App/FemConstraintBearing.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintContact.cpp
+++ b/src/Mod/Fem/App/FemConstraintContact.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                      <jrheinlaender[at]users.sourceforge.net>           *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintContact.h
+++ b/src/Mod/Fem/App/FemConstraintContact.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintFixed.cpp
+++ b/src/Mod/Fem/App/FemConstraintFixed.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintFixed.h
+++ b/src/Mod/Fem/App/FemConstraintFixed.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintFluidBoundary.h
+++ b/src/Mod/Fem/App/FemConstraintFluidBoundary.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintForce.cpp
+++ b/src/Mod/Fem/App/FemConstraintForce.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintForce.h
+++ b/src/Mod/Fem/App/FemConstraintForce.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintGear.cpp
+++ b/src/Mod/Fem/App/FemConstraintGear.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintGear.h
+++ b/src/Mod/Fem/App/FemConstraintGear.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/App/FemConstraintPlaneRotation.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintPlaneRotation.h
+++ b/src/Mod/Fem/App/FemConstraintPlaneRotation.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintPulley.cpp
+++ b/src/Mod/Fem/App/FemConstraintPulley.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintPulley.h
+++ b/src/Mod/Fem/App/FemConstraintPulley.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintTransform.cpp
+++ b/src/Mod/Fem/App/FemConstraintTransform.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemConstraintTransform.h
+++ b/src/Mod/Fem/App/FemConstraintTransform.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *

--- a/src/Mod/Fem/App/FemSolverObject.cpp
+++ b/src/Mod/Fem/App/FemSolverObject.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jürgen Riegel (FreeCAD@juergen-riegel.net)         *
- *   Copyright (c) 2015 Qingfeng Xia (FreeCAD@iesensor.com)                *
+ *   Copyright (c) 2013 Jürgen Riegel <FreeCAD@juergen-riegel.net>         *
+ *   Copyright (c) 2015 Qingfeng Xia  <FreeCAD@iesensor.com>               *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/Fem/App/FemSolverObject.cpp
+++ b/src/Mod/Fem/App/FemSolverObject.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2013 J¨¹rgen Riegel (FreeCAD@juergen-riegel.net)        *
+ *   Copyright (c) 2013 Jürgen Riegel (FreeCAD@juergen-riegel.net)         *
  *   Copyright (c) 2015 Qingfeng Xia (FreeCAD@iesensor.com)                *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *

--- a/src/Mod/Fem/App/FemVTKTools.cpp
+++ b/src/Mod/Fem/App/FemVTKTools.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) Jürgen Riegel          (juergen.riegel@web.de) 2009     *
-  *   Copyright (c) Qingfeng Xia         (qingfeng.xia at oxford uni) 2017     *
+ *   Copyright (c) Jürgen Riegel        (juergen.riegel@web.de) 2009       *
+ *   Copyright (c) Qingfeng Xia         (qingfeng.xia at oxford uni) 2017  *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/Fem/App/FemVTKTools.cpp
+++ b/src/Mod/Fem/App/FemVTKTools.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) Jürgen Riegel        (juergen.riegel@web.de) 2009       *
- *   Copyright (c) Qingfeng Xia         (qingfeng.xia at oxford uni) 2017  *
+ *   Copyright (c) 2009 Jürgen Riegel <juergen.riegel@web.de>              *
+ *   Copyright (c) 2017 Qingfeng Xia  <qingfeng.xia at oxford uni>         *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintBearing.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintBearing.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer <jrheinlaender[at]users.sourceforge.net>     *
- *                                                                         *
+ *   Copyright (c) 2013 Jan Rheinländer                                    *
+ *                          <jrheinlaender[at]users.sourceforge.net>       *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
  *   This library is free software; you can redistribute it and/or         *


### PR DESCRIPTION
This is a smaller PR of the recently closed #45
This addresses just `.cpp` and `.h` files