### PR TITLE
Fem: importFenicsMesh GuiUp guarding

### DIFF
--- a/src/Mod/Fem/ObjectsFem.py
+++ b/src/Mod/Fem/ObjectsFem.py
@@ -30,22 +30,34 @@ __url__ = "http://www.freecadweb.org"
 import FreeCAD
 
 
-# ********* analysis objects *********
-def makeAnalysis(doc, name="Analysis"):
-    '''makeAnalysis(document, [name]): makes a Fem Analysis object'''
+# ********* analysis objects *********************************************************************
+def makeAnalysis(
+    doc,
+    name="Analysis"
+):
+    '''makeAnalysis(document, [name]):
+    makes a Fem Analysis object'''
     obj = doc.addObject("Fem::FemAnalysis", name)
     return obj
 
 
-# ********* constraint objects *********
-def makeConstraintBearing(doc, name="ConstraintBearing"):
-    '''makeConstraintBearing(document, [name]): makes a Fem ConstraintBearing object'''
+# ********* constraint objects *******************************************************************
+def makeConstraintBearing(
+    doc,
+    name="ConstraintBearing"
+):
+    '''makeConstraintBearing(document, [name]):
+    makes a Fem ConstraintBearing object'''
     obj = doc.addObject("Fem::ConstraintBearing", name)
     return obj
 
 
-def makeConstraintBodyHeatSource(doc, name="ConstraintBodyHeatSource"):
-    '''makeConstraintBodyHeatSource(document, [name]): makes a Fem ConstraintBodyHeatSource object'''
+def makeConstraintBodyHeatSource(
+    doc,
+    name="ConstraintBodyHeatSource"
+):
+    '''makeConstraintBodyHeatSource(document, [name]):
+    makes a Fem ConstraintBodyHeatSource object'''
     obj = doc.addObject("Fem::ConstraintPython", name)
     from femobjects import _FemConstraintBodyHeatSource
     _FemConstraintBodyHeatSource.Proxy(obj)
@@ -55,20 +67,32 @@ def makeConstraintBodyHeatSource(doc, name="ConstraintBodyHeatSource"):
     return obj
 
 
-def makeConstraintContact(doc, name="ConstraintContact"):
-    '''makeConstraintContact(document, [name]): makes a Fem ConstraintContact object'''
+def makeConstraintContact(
+    doc,
+    name="ConstraintContact"
+):
+    '''makeConstraintContact(document, [name]):
+    makes a Fem ConstraintContact object'''
     obj = doc.addObject("Fem::ConstraintContact", name)
     return obj
 
 
-def makeConstraintDisplacement(doc, name="ConstraintDisplacement"):
-    '''makeConstraintDisplacement(document, [name]): makes a Fem ConstraintDisplacement object'''
+def makeConstraintDisplacement(
+    doc,
+    name="ConstraintDisplacement"
+):
+    '''makeConstraintDisplacement(document, [name]):
+    makes a Fem ConstraintDisplacement object'''
     obj = doc.addObject("Fem::ConstraintDisplacement", name)
     return obj
 
 
-def makeConstraintElectrostaticPotential(doc, name="ConstraintElectrostaticPotential"):
-    '''makeConstraintElectrostaticPotential(document, [name]): makes a Fem ElectrostaticPotential object'''
+def makeConstraintElectrostaticPotential(
+    doc,
+    name="ConstraintElectrostaticPotential"
+):
+    '''makeConstraintElectrostaticPotential(document, [name]):
+    makes a Fem ElectrostaticPotential object'''
     obj = doc.addObject("Fem::ConstraintPython", name)
     from femobjects import _FemConstraintElectrostaticPotential
     _FemConstraintElectrostaticPotential.Proxy(obj)
@@ -78,14 +102,22 @@ def makeConstraintElectrostaticPotential(doc, name="ConstraintElectrostaticPoten
     return obj
 
 
-def makeConstraintFixed(doc, name="ConstraintFixed"):
-    '''makeConstraintFixed(document, [name]): makes a Fem ConstraintFixed object'''
+def makeConstraintFixed(
+    doc,
+    name="ConstraintFixed"
+):
+    '''makeConstraintFixed(document, [name]):
+    makes a Fem ConstraintFixed object'''
     obj = doc.addObject("Fem::ConstraintFixed", name)
     return obj
 
 
-def makeConstraintFlowVelocity(doc, name="ConstraintFlowVelocity"):
-    '''makeConstraintFlowVelocity(document, [name]): makes a Fem ConstraintFlowVelocity object'''
+def makeConstraintFlowVelocity(
+    doc,
+    name="ConstraintFlowVelocity"
+):
+    '''makeConstraintFlowVelocity(document, [name]):
+    makes a Fem ConstraintFlowVelocity object'''
     obj = doc.addObject("Fem::ConstraintPython", name)
     from femobjects import _FemConstraintFlowVelocity
     _FemConstraintFlowVelocity.Proxy(obj)
@@ -95,32 +127,52 @@ def makeConstraintFlowVelocity(doc, name="ConstraintFlowVelocity"):
     return obj
 
 
-def makeConstraintFluidBoundary(doc, name="ConstraintFluidBoundary"):
-    '''makeConstraintFluidBoundary(document, name): makes a Fem ConstraintFluidBoundary object'''
+def makeConstraintFluidBoundary(
+    doc,
+    name="ConstraintFluidBoundary"
+):
+    '''makeConstraintFluidBoundary(document, name):
+    makes a Fem ConstraintFluidBoundary object'''
     obj = doc.addObject("Fem::ConstraintFluidBoundary", name)
     return obj
 
 
-def makeConstraintForce(doc, name="ConstraintForce"):
-    '''makeConstraintForce(document, [name]): makes a Fem ConstraintForce object'''
+def makeConstraintForce(
+    doc,
+    name="ConstraintForce"
+):
+    '''makeConstraintForce(document, [name]):
+    makes a Fem ConstraintForce object'''
     obj = doc.addObject("Fem::ConstraintForce", name)
     return obj
 
 
-def makeConstraintGear(doc, name="ConstraintGear"):
-    '''makeConstraintGear(document, [name]): makes a Fem ConstraintGear object'''
+def makeConstraintGear(
+    doc,
+    name="ConstraintGear"
+):
+    '''makeConstraintGear(document, [name]):
+    makes a Fem ConstraintGear object'''
     obj = doc.addObject("Fem::ConstraintGear", name)
     return obj
 
 
-def makeConstraintHeatflux(doc, name="ConstraintHeatflux"):
-    '''makeConstraintHeatflux(document, [name]): makes a Fem ConstraintHeatflux object'''
+def makeConstraintHeatflux(
+    doc,
+    name="ConstraintHeatflux"
+):
+    '''makeConstraintHeatflux(document, [name]):
+    makes a Fem ConstraintHeatflux object'''
     obj = doc.addObject("Fem::ConstraintHeatflux", name)
     return obj
 
 
-def makeConstraintInitialFlowVelocity(doc, name="ConstraintInitialFlowVelocity"):
-    '''makeConstraintInitialFlowVelocity(document, [name]): makes a Fem ConstraintInitialFlowVelocity object'''
+def makeConstraintInitialFlowVelocity(
+    doc,
+    name="ConstraintInitialFlowVelocity"
+):
+    '''makeConstraintInitialFlowVelocity(document, [name]):
+    makes a Fem ConstraintInitialFlowVelocity object'''
     obj = doc.addObject("Fem::ConstraintPython", name)
     from femobjects import _FemConstraintInitialFlowVelocity
     _FemConstraintInitialFlowVelocity.Proxy(obj)
@@ -130,56 +182,90 @@ def makeConstraintInitialFlowVelocity(doc, name="ConstraintInitialFlowVelocity")
     return obj
 
 
-def makeConstraintInitialTemperature(doc, name="ConstraintInitialTemperature"):
-    '''makeConstraintInitialTemperature(document, name): makes a Fem ConstraintInitialTemperature object'''
+def makeConstraintInitialTemperature(
+    doc,
+    name="ConstraintInitialTemperature"
+):
+    '''makeConstraintInitialTemperature(document, name):
+    makes a Fem ConstraintInitialTemperature object'''
     obj = doc.addObject("Fem::ConstraintInitialTemperature", name)
     return obj
 
 
-def makeConstraintPlaneRotation(doc, name="ConstraintPlaneRotation"):
-    '''makeConstraintPlaneRotation(document, [name]): makes a Fem ConstraintPlaneRotation object'''
+def makeConstraintPlaneRotation(
+    doc,
+    name="ConstraintPlaneRotation"
+):
+    '''makeConstraintPlaneRotation(document, [name]):
+    makes a Fem ConstraintPlaneRotation object'''
     obj = doc.addObject("Fem::ConstraintPlaneRotation", name)
     return obj
 
 
-def makeConstraintPressure(doc, name="ConstraintPressure"):
-    '''makeConstraintPressure(document, [name]): makes a Fem ConstraintPressure object'''
+def makeConstraintPressure(
+    doc,
+    name="ConstraintPressure"
+):
+    '''makeConstraintPressure(document, [name]):
+    makes a Fem ConstraintPressure object'''
     obj = doc.addObject("Fem::ConstraintPressure", name)
     return obj
 
 
-def makeConstraintPulley(doc, name="ConstraintPulley"):
-    '''makeConstraintPulley(document, [name]): makes a Fem ConstraintPulley object'''
+def makeConstraintPulley(
+    doc,
+    name="ConstraintPulley"
+):
+    '''makeConstraintPulley(document, [name]):
+    makes a Fem ConstraintPulley object'''
     obj = doc.addObject("Fem::ConstraintPulley", name)
     return obj
 
 
-def makeConstraintSelfWeight(doc, name="ConstraintSelfWeight"):
-    '''makeConstraintSelfWeight(document, [name]): creates an self weight object to define a gravity load'''
+def makeConstraintSelfWeight(
+    doc,
+    name="ConstraintSelfWeight"
+):
+    '''makeConstraintSelfWeight(document, [name]):
+    creates an self weight object to define a gravity load'''
     obj = doc.addObject("Fem::ConstraintPython", name)
     from femobjects import _FemConstraintSelfWeight
     _FemConstraintSelfWeight._FemConstraintSelfWeight(obj)
     if FreeCAD.GuiUp:
         from femguiobjects import _ViewProviderFemConstraintSelfWeight
-        _ViewProviderFemConstraintSelfWeight._ViewProviderFemConstraintSelfWeight(obj.ViewObject)
+        _ViewProviderFemConstraintSelfWeight._ViewProviderFemConstraintSelfWeight(
+            obj.ViewObject
+        )
     return obj
 
 
-def makeConstraintTemperature(doc, name="ConstraintTemperature"):
-    '''makeConstraintTemperature(document, [name]): makes a Fem ConstraintTemperature object'''
+def makeConstraintTemperature(
+    doc,
+    name="ConstraintTemperature"
+):
+    '''makeConstraintTemperature(document, [name]):
+    makes a Fem ConstraintTemperature object'''
     obj = doc.addObject("Fem::ConstraintTemperature", name)
     return obj
 
 
-def makeConstraintTransform(doc, name="ConstraintTransform"):
-    '''makeConstraintTransform(document, [name]): makes a Fem ConstraintTransform object'''
+def makeConstraintTransform(
+    doc,
+    name="ConstraintTransform"
+):
+    '''makeConstraintTransform(document, [name]):
+    makes a Fem ConstraintTransform object'''
     obj = doc.addObject("Fem::ConstraintTransform", name)
     return obj
 
 
-# ********* element definition objects *********
-def makeElementFluid1D(doc, name="ElementFluid1D"):
-    '''makeElementFluid1D(document, [name]): creates an 1D fluid element object to define 1D flow'''
+# ********* element definition objects ***********************************************************
+def makeElementFluid1D(
+    doc,
+    name="ElementFluid1D"
+):
+    '''makeElementFluid1D(document, [name]):
+    creates an 1D fluid element object to define 1D flow'''
     obj = doc.addObject("Fem::FeaturePython", name)
     from femobjects import _FemElementFluid1D
     _FemElementFluid1D._FemElementFluid1D(obj)
@@ -189,8 +275,15 @@ def makeElementFluid1D(doc, name="ElementFluid1D"):
     return obj
 
 
-def makeElementGeometry1D(doc, sectiontype='Rectangular', width=10.0, height=25.0, name="ElementGeometry1D"):
-    '''makeElementGeometry1D(document, [width], [height], [name]): creates an 1D geometry element object to define a cross section'''
+def makeElementGeometry1D(
+    doc,
+    sectiontype='Rectangular',
+    width=10.0,
+    height=25.0,
+    name="ElementGeometry1D"
+):
+    '''makeElementGeometry1D(document, [width], [height], [name]):
+    creates an 1D geometry element object to define a cross section'''
     obj = doc.addObject("Fem::FeaturePython", name)
     from femobjects import _FemElementGeometry1D
     _FemElementGeometry1D._FemElementGeometry1D(obj)
@@ -211,8 +304,13 @@ def makeElementGeometry1D(doc, sectiontype='Rectangular', width=10.0, height=25.
     return obj
 
 
-def makeElementGeometry2D(doc, thickness=20.0, name="ElementGeometry2D"):
-    '''makeElementGeometry2D(document, [thickness], [name]): creates an 2D geometry element object to define a plate thickness'''
+def makeElementGeometry2D(
+    doc,
+    thickness=20.0,
+    name="ElementGeometry2D"
+):
+    '''makeElementGeometry2D(document, [thickness], [name]):
+    creates an 2D geometry element object to define a plate thickness'''
     obj = doc.addObject("Fem::FeaturePython", name)
     from femobjects import _FemElementGeometry2D
     _FemElementGeometry2D._FemElementGeometry2D(obj)
@@ -223,8 +321,12 @@ def makeElementGeometry2D(doc, thickness=20.0, name="ElementGeometry2D"):
     return obj
 
 
-def makeElementRotation1D(doc, name="ElementRotation1D"):
-    '''makeElementRotation1D(document, [name]): creates an 1D geometry rotation element object to rotate a 1D cross section'''
+def makeElementRotation1D(
+    doc,
+    name="ElementRotation1D"
+):
+    '''makeElementRotation1D(document, [name]):
+    creates an 1D geometry rotation element object to rotate a 1D cross section'''
     obj = doc.addObject("Fem::FeaturePython", name)
     from femobjects import _FemElementRotation1D
     _FemElementRotation1D._FemElementRotation1D(obj)
@@ -234,8 +336,11 @@ def makeElementRotation1D(doc, name="ElementRotation1D"):
     return obj
 
 
-# ********* material objects *********
-def makeMaterialFluid(doc, name="FluidMaterial"):
+# ********* material objects *********************************************************************
+def makeMaterialFluid(
+    doc,
+    name="FluidMaterial"
+):
     '''makeMaterialFluid(document, [name]): makes a FEM Material for fluid'''
     obj = doc.addObject("App::MaterialObjectPython", name)
     from femobjects import _FemMaterial
@@ -247,19 +352,29 @@ def makeMaterialFluid(doc, name="FluidMaterial"):
     return obj
 
 
-def makeMaterialMechanicalNonlinear(doc, base_material, name="MechanicalMaterialNonlinear"):
-    '''makeMaterialMechanicalNonlinear(document, base_material, [name]): creates a nonlinear material object'''
+def makeMaterialMechanicalNonlinear(
+    doc,
+    base_material,
+    name="MechanicalMaterialNonlinear"
+):
+    '''makeMaterialMechanicalNonlinear(document, base_material, [name]):
+    creates a nonlinear material object'''
     obj = doc.addObject("Fem::FeaturePython", name)
     from femobjects import _FemMaterialMechanicalNonlinear
     _FemMaterialMechanicalNonlinear._FemMaterialMechanicalNonlinear(obj)
     obj.LinearBaseMaterial = base_material
     if FreeCAD.GuiUp:
         from femguiobjects import _ViewProviderFemMaterialMechanicalNonlinear
-        _ViewProviderFemMaterialMechanicalNonlinear._ViewProviderFemMaterialMechanicalNonlinear(obj.ViewObject)
+        _ViewProviderFemMaterialMechanicalNonlinear._ViewProviderFemMaterialMechanicalNonlinear(
+            obj.ViewObject
+        )
     return obj
 
 
-def makeMaterialSolid(doc, name="MechanicalSolidMaterial"):
+def makeMaterialSolid(
+    doc,
+    name="MechanicalSolidMaterial"
+):
     '''makeMaterialSolid(document, [name]): makes a FEM Material for solid'''
     obj = doc.addObject("App::MaterialObjectPython", name)
     from femobjects import _FemMaterial
@@ -271,14 +386,20 @@ def makeMaterialSolid(doc, name="MechanicalSolidMaterial"):
     return obj
 
 
-# ********* mesh objects *********
-def makeMeshBoundaryLayer(doc, base_mesh, name="MeshBoundaryLayer"):
-    '''makeMeshBoundaryLayer(document, base_mesh, [name]): creates a FEM mesh BoundaryLayer object to define boundary layer properties'''
+# ********* mesh objects *************************************************************************
+def makeMeshBoundaryLayer(
+    doc,
+    base_mesh,
+    name="MeshBoundaryLayer"
+):
+    '''makeMeshBoundaryLayer(document, base_mesh, [name]):
+    creates a FEM mesh BoundaryLayer object to define boundary layer properties'''
     obj = doc.addObject("Fem::FeaturePython", name)
     from femobjects import _FemMeshBoundaryLayer
     _FemMeshBoundaryLayer._FemMeshBoundaryLayer(obj)
     # obj.BaseMesh = base_mesh
-    # App::PropertyLinkList does not support append, we will use a temporary list to append the mesh BoundaryLayer obj. to the list
+    # App::PropertyLinkList does not support append
+    # we will use a temporary list to append the mesh BoundaryLayer obj. to the list
     tmplist = base_mesh.MeshBoundaryLayerList
     tmplist.append(obj)
     base_mesh.MeshBoundaryLayerList = tmplist
@@ -288,7 +409,10 @@ def makeMeshBoundaryLayer(doc, base_mesh, name="MeshBoundaryLayer"):
     return obj
 
 
-def makeMeshGmsh(doc, name="FEMMeshGmsh"):
+def makeMeshGmsh(
+    doc,
+    name="FEMMeshGmsh"
+):
     '''makeMeshGmsh(document, [name]): makes a Gmsh FEM mesh object'''
     obj = doc.addObject("Fem::FemMeshObjectPython", name)
     from femobjects import _FemMeshGmsh
@@ -299,14 +423,21 @@ def makeMeshGmsh(doc, name="FEMMeshGmsh"):
     return obj
 
 
-def makeMeshGroup(doc, base_mesh, use_label=False, name="FEMMeshGroup"):
-    '''makeMeshGroup(document, base_mesh, [use_label], [name]): creates a FEM mesh region object to define properties for a region of a FEM mesh'''
+def makeMeshGroup(
+    doc,
+    base_mesh,
+    use_label=False,
+    name="FEMMeshGroup"
+):
+    '''makeMeshGroup(document, base_mesh, [use_label], [name]):
+    creates a FEM mesh region object to define properties for a region of a FEM mesh'''
     obj = doc.addObject("Fem::FeaturePython", name)
     from femobjects import _FemMeshGroup
     _FemMeshGroup._FemMeshGroup(obj)
     obj.UseLabel = use_label
     # obj.BaseMesh = base_mesh
-    # App::PropertyLinkList does not support append, we will use a temporary list to append the mesh group obj. to the list
+    # App::PropertyLinkList does not support append
+    # we will use a temporary list to append the mesh group obj. to the list
     tmplist = base_mesh.MeshGroupList
     tmplist.append(obj)
     base_mesh.MeshGroupList = tmplist
@@ -316,13 +447,21 @@ def makeMeshGroup(doc, base_mesh, use_label=False, name="FEMMeshGroup"):
     return obj
 
 
-def makeMeshNetgen(doc, name="FEMMeshNetgen"):
+def makeMeshNetgen(
+    doc,
+    name="FEMMeshNetgen"
+):
     '''makeMeshNetgen(document, [name]): makes a Fem MeshShapeNetgenObject object'''
     obj = doc.addObject("Fem::FemMeshShapeNetgenObject", name)
     return obj
 
 
-def makeMeshRegion(doc, base_mesh, element_length=0.0, name="FEMMeshRegion"):
+def makeMeshRegion(
+    doc,
+    base_mesh,
+    element_length=0.0,
+    name="FEMMeshRegion"
+):
     '''makeMeshRegion(document, base_mesh, [element_length], [name]):
     creates a FEM mesh region object to define properties for a region of a FEM mesh'''
     obj = doc.addObject("Fem::FeaturePython", name)
@@ -330,7 +469,8 @@ def makeMeshRegion(doc, base_mesh, element_length=0.0, name="FEMMeshRegion"):
     _FemMeshRegion._FemMeshRegion(obj)
     obj.CharacteristicLength = element_length
     # obj.BaseMesh = base_mesh
-    # App::PropertyLinkList does not support append, we will use a temporary list to append the mesh region obj. to the list
+    # App::PropertyLinkList does not support append
+    # we will use a temporary list to append the mesh region obj. to the list
     tmplist = base_mesh.MeshRegionList
     tmplist.append(obj)
     base_mesh.MeshRegionList = tmplist
@@ -340,7 +480,10 @@ def makeMeshRegion(doc, base_mesh, element_length=0.0, name="FEMMeshRegion"):
     return obj
 
 
-def makeMeshResult(doc, name="FEMMeshResult"):
+def makeMeshResult(
+    doc,
+    name="FEMMeshResult"
+):
     '''makeMeshResult(document, name): makes a Fem MeshResult object'''
     obj = doc.addObject("Fem::FemMeshObjectPython", name)
     from femobjects import _FemMeshResult
@@ -351,9 +494,13 @@ def makeMeshResult(doc, name="FEMMeshResult"):
     return obj
 
 
-# ********* post processing objects *********
-def makeResultMechanical(doc, name="MechanicalResult"):
-    '''makeResultMechanical(document, [name]): creates an mechanical result object to hold FEM results'''
+# ********* post processing objects **************************************************************
+def makeResultMechanical(
+    doc,
+    name="MechanicalResult"
+):
+    '''makeResultMechanical(document, [name]):
+    creates an mechanical result object to hold FEM results'''
     obj = doc.addObject('Fem::FemResultObjectPython', name)
     from femobjects import _FemResultMechanical
     _FemResultMechanical._FemResultMechanical(obj)
@@ -363,8 +510,13 @@ def makeResultMechanical(doc, name="MechanicalResult"):
     return obj
 
 
-def makePostVtkFilterClipRegion(doc, base_vtk_result, name="FEMVtkFilterClipRegion"):
-    '''makePostVtkFilterClipRegion(document, base_vtk_result, [name]): creates an FEM post processing region clip filter object (vtk based)'''
+def makePostVtkFilterClipRegion(
+    doc,
+    base_vtk_result,
+    name="FEMVtkFilterClipRegion"
+):
+    '''makePostVtkFilterClipRegion(document, base_vtk_result, [name]):
+    creates an FEM post processing region clip filter object (vtk based)'''
     obj = doc.addObject("Fem::FemPostClipFilter", name)
     tmp_filter_list = base_vtk_result.Filter
     tmp_filter_list.append(obj)
@@ -373,8 +525,13 @@ def makePostVtkFilterClipRegion(doc, base_vtk_result, name="FEMVtkFilterClipRegi
     return obj
 
 
-def makePostVtkFilterClipScalar(doc, base_vtk_result, name="FEMVtkFilterClipScalar"):
-    '''makePostVtkFilterClipScalar(document, base_vtk_result, [name]): creates an FEM post processing scalar clip filter object (vtk based)'''
+def makePostVtkFilterClipScalar(
+    doc,
+    base_vtk_result,
+    name="FEMVtkFilterClipScalar"
+):
+    '''makePostVtkFilterClipScalar(document, base_vtk_result, [name]):
+    creates an FEM post processing scalar clip filter object (vtk based)'''
     obj = doc.addObject("Fem::FemPostScalarClipFilter", name)
     tmp_filter_list = base_vtk_result.Filter
     tmp_filter_list.append(obj)
@@ -383,8 +540,13 @@ def makePostVtkFilterClipScalar(doc, base_vtk_result, name="FEMVtkFilterClipScal
     return obj
 
 
-def makePostVtkFilterCutFunction(doc, base_vtk_result, name="FEMVtkFilterCutFunction"):
-    '''makePostVtkFilterCutFunction(document, base_vtk_result, [name]): creates an FEM post processing cut function filter object (vtk based)'''
+def makePostVtkFilterCutFunction(
+    doc,
+    base_vtk_result,
+    name="FEMVtkFilterCutFunction"
+):
+    '''makePostVtkFilterCutFunction(document, base_vtk_result, [name]):
+    creates an FEM post processing cut function filter object (vtk based)'''
     obj = doc.addObject("Fem::FemPostClipFilter", name)
     tmp_filter_list = base_vtk_result.Filter
     tmp_filter_list.append(obj)
@@ -393,8 +555,13 @@ def makePostVtkFilterCutFunction(doc, base_vtk_result, name="FEMVtkFilterCutFunc
     return obj
 
 
-def makePostVtkFilterWarp(doc, base_vtk_result, name="FEMVtkFilterWarp"):
-    '''makePostVtkFilterWarp(document, base_vtk_result, [name]): creates an FEM post processing warp filter object (vtk based)'''
+def makePostVtkFilterWarp(
+    doc,
+    base_vtk_result,
+    name="FEMVtkFilterWarp"
+):
+    '''makePostVtkFilterWarp(document, base_vtk_result, [name]):
+    creates an FEM post processing warp filter object (vtk based)'''
     obj = doc.addObject("Fem::FemPostWarpVectorFilter", name)
     tmp_filter_list = base_vtk_result.Filter
     tmp_filter_list.append(obj)
@@ -403,46 +570,84 @@ def makePostVtkFilterWarp(doc, base_vtk_result, name="FEMVtkFilterWarp"):
     return obj
 
 
-def makePostVtkResult(doc, base_result, name="FEMVtkResult"):
-    '''makePostVtkResult(document, base_result [name]): creates an FEM post processing result object (vtk based) to hold FEM results'''
+def makePostVtkResult(
+    doc, base_result,
+    name="FEMVtkResult"
+):
+    '''makePostVtkResult(document, base_result [name]):
+    creates an FEM post processing result object (vtk based) to hold FEM results'''
     obj = doc.addObject("Fem::FemPostPipeline", name)
     obj.load(base_result)
     return obj
 
 
-# ********* solver objects *********
-def makeEquationElasticity(doc, base_solver):
-    '''makeEquationElasticity(document, base_solver): creates a FEM elasticity equation for a solver'''
-    obj = doc.SolverElmer.addObject(doc.SolverElmer.Proxy.createEquation(doc.SolverElmer.Document, 'Elasticity'))[0]
+# ********* solver objects ***********************************************************************
+def makeEquationElasticity(
+    doc,
+    base_solver
+):
+    '''makeEquationElasticity(document, base_solver):
+    creates a FEM elasticity equation for a solver'''
+    obj = doc.SolverElmer.addObject(
+        doc.SolverElmer.Proxy.createEquation(doc.SolverElmer.Document, 'Elasticity')
+    )[0]
     return obj
 
 
-def makeEquationElectrostatic(doc, base_solver):
-    '''makeEquationElectrostatic(document, base_solver): creates a FEM electrostatic equation for a solver'''
-    obj = doc.SolverElmer.addObject(doc.SolverElmer.Proxy.createEquation(doc.SolverElmer.Document, 'Electrostatic'))[0]
+def makeEquationElectrostatic(
+    doc,
+    base_solver
+):
+    '''makeEquationElectrostatic(document, base_solver):
+    creates a FEM electrostatic equation for a solver'''
+    obj = doc.SolverElmer.addObject(
+        doc.SolverElmer.Proxy.createEquation(doc.SolverElmer.Document, 'Electrostatic')
+    )[0]
     return obj
 
 
-def makeEquationFlow(doc, base_solver):
-    '''makeEquationFlow(document, base_solver): creates a FEM flow equation for a solver'''
-    obj = doc.SolverElmer.addObject(doc.SolverElmer.Proxy.createEquation(doc.SolverElmer.Document, 'Flow'))[0]
+def makeEquationFlow(
+    doc,
+    base_solver
+):
+    '''makeEquationFlow(document, base_solver):
+    creates a FEM flow equation for a solver'''
+    obj = doc.SolverElmer.addObject(
+        doc.SolverElmer.Proxy.createEquation(doc.SolverElmer.Document, 'Flow')
+    )[0]
     return obj
 
 
-def makeEquationFluxsolver(doc, base_solver):
-    '''makeEquationFluxsolver(document, base_solver): creates a FEM fluxsolver equation for a solver'''
-    obj = doc.SolverElmer.addObject(doc.SolverElmer.Proxy.createEquation(doc.SolverElmer.Document, 'Fluxsolver'))[0]
+def makeEquationFluxsolver(
+    doc,
+    base_solver
+):
+    '''makeEquationFluxsolver(document, base_solver):
+    creates a FEM fluxsolver equation for a solver'''
+    obj = doc.SolverElmer.addObject(
+        doc.SolverElmer.Proxy.createEquation(doc.SolverElmer.Document, 'Fluxsolver')
+    )[0]
     return obj
 
 
-def makeEquationHeat(doc, base_solver):
-    '''makeEquationHeat(document, base_solver): creates a FEM heat equation for a solver'''
-    obj = doc.SolverElmer.addObject(doc.SolverElmer.Proxy.createEquation(doc.SolverElmer.Document, 'Heat'))[0]
+def makeEquationHeat(
+    doc,
+    base_solver
+):
+    '''makeEquationHeat(document, base_solver):
+    creates a FEM heat equation for a solver'''
+    obj = doc.SolverElmer.addObject(
+        doc.SolverElmer.Proxy.createEquation(doc.SolverElmer.Document, 'Heat')
+    )[0]
     return obj
 
 
-def makeSolverCalculixCcxTools(doc, name="CalculiXccxTools"):
-    '''makeSolverCalculixCcxTools(document, [name]): makes a Calculix solver object for the ccx tools module'''
+def makeSolverCalculixCcxTools(
+    doc,
+    name="CalculiXccxTools"
+):
+    '''makeSolverCalculixCcxTools(document, [name]):
+    makes a Calculix solver object for the ccx tools module'''
     obj = doc.addObject("Fem::FemSolverObjectPython", name)
     from femobjects import _FemSolverCalculix
     _FemSolverCalculix._FemSolverCalculix(obj)
@@ -452,22 +657,34 @@ def makeSolverCalculixCcxTools(doc, name="CalculiXccxTools"):
     return obj
 
 
-def makeSolverCalculix(doc, name="SolverCalculiX"):
-    '''makeSolverCalculix(document, [name]): makes a Calculix solver object'''
+def makeSolverCalculix(
+    doc,
+    name="SolverCalculiX"
+):
+    '''makeSolverCalculix(document, [name]):
+    makes a Calculix solver object'''
     import femsolver.calculix.solver
     obj = femsolver.calculix.solver.create(doc, name)
     return obj
 
 
-def makeSolverElmer(doc, name="SolverElmer"):
-    '''makeSolverElmer(document, [name]): makes a Elmer solver object'''
+def makeSolverElmer(
+    doc,
+    name="SolverElmer"
+):
+    '''makeSolverElmer(document, [name]):
+    makes a Elmer solver object'''
     import femsolver.elmer.solver
     obj = femsolver.elmer.solver.create(doc, name)
     return obj
 
 
-def makeSolverZ88(doc, name="SolverZ88"):
-    '''makeSolverZ88(document, [name]): makes a Z88 solver object'''
+def makeSolverZ88(
+    doc,
+    name="SolverZ88"
+):
+    '''makeSolverZ88(document, [name]):
+    makes a Z88 solver object'''
     import femsolver.z88.solver
     obj = femsolver.z88.solver.create(doc, name)
     return obj

--- a/src/Mod/Fem/feminout/importCcxFrdResults.py
+++ b/src/Mod/Fem/feminout/importCcxFrdResults.py
@@ -125,7 +125,7 @@ def importFrd(filename, analysis=None, result_name_prefix=None):
 
     else:
         FreeCAD.Console.PrintError('Problem on frd file import. No nodes found in frd file.\n')
-
+    return res_obj
 
 # read a calculix result file and extract the nodes, displacement vectors and stress values.
 def read_frd_result(frd_input):

--- a/src/Mod/Fem/feminout/importFenicsMesh.py
+++ b/src/Mod/Fem/feminout/importFenicsMesh.py
@@ -28,11 +28,14 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 #  \brief FreeCAD Fenics Mesh reader and writer for FEM workbench
 
-from PySide import QtGui, QtCore
+import os
 
 import FreeCAD
 import FreeCADGui
-import os
+
+if FreeCAD.GuiUp == 1:
+    from PySide import QtGui, QtCore
+
 
 from . import importToolsFem
 from . import readFenicsXML
@@ -49,75 +52,93 @@ elif open.__module__ == 'io':
     # because we'll redefine open below (Python3)
     pyopen = open
 
+if FreeCAD.GuiUp == 1:
+    class WriteXDMFTaskPanel:
+        """
+        This task panel is used to write mesh groups with user defined values.
+        It will called if there are mesh groups detected. Else it will be bypassed.
+        """
+        def __init__(self, fem_mesh_obj, fileString):
+            self.form = FreeCADGui.PySideUic.loadUi(
+                FreeCAD.getHomePath() +
+                "Mod/Fem/Resources/ui/MeshGroupXDMFExport.ui")
+            self.result_dict = {}
+            self.fem_mesh_obj = fem_mesh_obj
+            self.fileString = fileString
 
-class WriteXDMFTaskPanel:
-    """
-    This task panel is used to write mesh groups with user defined values.
-    It will called if there are mesh groups detected. Else it will be bypassed.
-    """
-    def __init__(self, fem_mesh_obj, fileString):
-        self.form = FreeCADGui.PySideUic.loadUi(FreeCAD.getHomePath() + "Mod/Fem/Resources/ui/MeshGroupXDMFExport.ui")
-        self.result_dict = {}
-        self.fem_mesh_obj = fem_mesh_obj
-        self.fileString = fileString
+            self.convert_fem_mesh_obj_to_table()
 
-        self.convert_fem_mesh_obj_to_table()
+        def convert_fem_mesh_obj_to_table(self):
 
-    def convert_fem_mesh_obj_to_table(self):
+            def ro(item):
+                item.setFlags(~QtCore.Qt.ItemIsEditable & ~QtCore.Qt.ItemIsEnabled)
+                return item
 
-        def ro(item):
-            item.setFlags(~QtCore.Qt.ItemIsEditable & ~QtCore.Qt.ItemIsEnabled)
-            return item
+            gmshgroups = importToolsFem.get_FemMeshObjectMeshGroups(
+                            self.fem_mesh_obj)
+            fem_mesh = self.fem_mesh_obj.FemMesh
 
-        gmshgroups = importToolsFem.get_FemMeshObjectMeshGroups(self.fem_mesh_obj)
-        fem_mesh = self.fem_mesh_obj.FemMesh
+            self.form.tableGroups.setRowCount(0)
+            self.form.tableGroups.setRowCount(len(gmshgroups))
 
-        self.form.tableGroups.setRowCount(0)
-        self.form.tableGroups.setRowCount(len(gmshgroups))
+            for (ind, gind) in enumerate(gmshgroups):
+                # group number
+                self.form.tableGroups.setItem(ind, 0,
+                                              ro(QtGui.QTableWidgetItem(
+                                                  str(gind))))
+                # group name
+                self.form.tableGroups.setItem(ind, 1,
+                                              ro(QtGui.QTableWidgetItem(
+                                                  fem_mesh.getGroupName(gind))))
+                # group elements
+                self.form.tableGroups.setItem(ind, 2,
+                                              ro(QtGui.QTableWidgetItem(
+                                                  fem_mesh.getGroupElementType(
+                                                      gind))))
+                # default value for not marked elements
+                self.form.tableGroups.setItem(ind, 3,
+                                              QtGui.QTableWidgetItem(str(0)))
+                # default value for marked elements
+                self.form.tableGroups.setItem(ind, 4,
+                                              QtGui.QTableWidgetItem(str(1)))
 
-        for (ind, gind) in enumerate(gmshgroups):
-            # group number
-            self.form.tableGroups.setItem(ind, 0, ro(QtGui.QTableWidgetItem(str(gind))))
-            # group name
-            self.form.tableGroups.setItem(ind, 1, ro(QtGui.QTableWidgetItem(fem_mesh.getGroupName(gind))))
-            # group elements
-            self.form.tableGroups.setItem(ind, 2, ro(QtGui.QTableWidgetItem(fem_mesh.getGroupElementType(gind))))
-            # default value for not marked elements
-            self.form.tableGroups.setItem(ind, 3, QtGui.QTableWidgetItem(str(0)))
-            # default value for marked elements
-            self.form.tableGroups.setItem(ind, 4, QtGui.QTableWidgetItem(str(1)))
+            header = self.form.tableGroups.horizontalHeader()
+            header.setResizeMode(0, QtGui.QHeaderView.ResizeToContents)
+            header.setResizeMode(1, QtGui.QHeaderView.ResizeToContents)
+            header.setResizeMode(2, QtGui.QHeaderView.ResizeToContents)
+            header.setResizeMode(3, QtGui.QHeaderView.ResizeToContents)
+            header.setResizeMode(4, QtGui.QHeaderView.Stretch)
 
-        header = self.form.tableGroups.horizontalHeader()
-        header.setResizeMode(0, QtGui.QHeaderView.ResizeToContents)
-        header.setResizeMode(1, QtGui.QHeaderView.ResizeToContents)
-        header.setResizeMode(2, QtGui.QHeaderView.ResizeToContents)
-        header.setResizeMode(3, QtGui.QHeaderView.ResizeToContents)
-        header.setResizeMode(4, QtGui.QHeaderView.Stretch)
+        def convert_table_to_group_dict(self):
+            group_values_dict = {}
+            num_rows = self.form.tableGroups.rowCount()
 
-    def convert_table_to_group_dict(self):
-        group_values_dict = {}
-        num_rows = self.form.tableGroups.rowCount()
+            for r in range(num_rows):
+                g = int(self.form.tableGroups.item(r, 0).text())
+                # read-only no prob
+                default_value = 0
+                marked_value = 1
+                try:
+                    default_value = int(self.form.tableGroups.item(r, 3).text())
+                    marked_value = int(self.form.tableGroups.item(r, 4).text())
+                except ValueError:
+                    FreeCAD.Console.PrintError(
+                        "ERROR: value conversion failed " +
+                        "in table to dict: assuming 0 for default, " +
+                        "1 for marked.\n")
 
-        for r in range(num_rows):
-            g = int(self.form.tableGroups.item(r, 0).text())  # read-only no prob
-            default_value = 0
-            marked_value = 1
-            try:
-                default_value = int(self.form.tableGroups.item(r, 3).text())
-                marked_value = int(self.form.tableGroups.item(r, 4).text())
-            except:
-                FreeCAD.Console.PrintError("ERROR: value conversion failed in table to dict: assuming 0 for default, 1 for marked.\n")
+                group_values_dict[g] = (marked_value, default_value)
 
-            group_values_dict[g] = (marked_value, default_value)
+            return group_values_dict
 
-        return group_values_dict
+        def accept(self):
+            group_values_dict = self.convert_table_to_group_dict()
 
-    def accept(self):
-        group_values_dict = self.convert_table_to_group_dict()
+            writeFenicsXDMF.write_fenics_mesh_xdmf(
+                self.fem_mesh_obj, self.fileString,
+                group_values_dict=group_values_dict)
 
-        writeFenicsXDMF.write_fenics_mesh_xdmf(self.fem_mesh_obj, self.fileString, group_values_dict=group_values_dict)
-
-        FreeCADGui.Control.closeDialog()
+            FreeCADGui.Control.closeDialog()
 
 
 def open(filename):
@@ -136,10 +157,15 @@ def insert(filename, docname):
     import_fenics_mesh(filename)
 
 
-def export(objectslist, fileString):
-    "called when freecad exports a file"
+def export(objectslist, fileString, group_values_dict_nogui=None):
+    """
+    Called when freecad exports a file.
+    group_dict_no_gui: dictionary with group_numbers as keys and tuples
+    of (marked_value (default=1), default_value (default=0))
+    """
     if len(objectslist) != 1:
-        FreeCAD.Console.PrintError("This exporter can only export one object.\n")
+        FreeCAD.Console.PrintError(
+            "This exporter can only export one object.\n")
         return
     obj = objectslist[0]
     if not obj.isDerivedFrom("Fem::FemMeshObject"):
@@ -149,15 +175,27 @@ def export(objectslist, fileString):
     if fileString != "":
         fileName, fileExtension = os.path.splitext(fileString)
         if fileExtension.lower() == '.xml':
-            FreeCAD.Console.PrintWarning("XML is not designed to save higher order elements.\n")
-            FreeCAD.Console.PrintWarning("Reducing order for second order mesh.\n")
+            FreeCAD.Console.PrintWarning(
+                "XML is not designed to save higher order elements.\n")
+            FreeCAD.Console.PrintWarning(
+                "Reducing order for second order mesh.\n")
             FreeCAD.Console.PrintWarning("Tri6 -> Tri3, Tet10 -> Tet4, etc.\n")
             writeFenicsXML.write_fenics_mesh_xml(obj, fileString)
         elif fileExtension.lower() == '.xdmf':
-            if importToolsFem.get_FemMeshObjectMeshGroups(obj) is not ():
-                # if there are groups found, make task panel available
-                panel = WriteXDMFTaskPanel(obj, fileString)
-                FreeCADGui.Control.showDialog(panel)
+            mesh_groups = importToolsFem.get_FemMeshObjectMeshGroups(obj)
+            if mesh_groups is not ():
+                # if there are groups found, make task panel available if GuiUp
+                if FreeCAD.GuiUp == 1:
+                    panel = WriteXDMFTaskPanel(obj, fileString)
+                    FreeCADGui.Control.showDialog(panel)
+                else:
+                    # create default dict if groupdict_nogui is not None
+                    if group_values_dict_nogui is None:
+                        group_values_dict_nogui = dict([(g, (1, 0))
+                                                        for g in mesh_groups])
+                    writeFenicsXDMF.write_fenics_mesh_xdmf(
+                        obj, fileString,
+                        group_values_dict=group_values_dict_nogui)
             else:
                 writeFenicsXDMF.write_fenics_mesh_xdmf(obj, fileString)
 

--- a/src/Mod/Fem/feminout/importVTKResults.py
+++ b/src/Mod/Fem/feminout/importVTKResults.py
@@ -113,6 +113,7 @@ def importVtkFemMesh(filename, meshname):
     meshobj.FemMesh = Fem.read(filename)
     meshobj.touch()
     FreeCAD.ActiveDocument.recompute()
+    return meshobj
 
 
 def importVtkFCResult(filename, resultname, analysis=None, result_name_prefix=None):
@@ -147,3 +148,4 @@ def importVtkFCResult(filename, resultname, analysis=None, result_name_prefix=No
         analysis_object.addObject(result_obj)
     result_obj.touch()
     FreeCAD.ActiveDocument.recompute()
+    return result_obj

--- a/src/Mod/Material/materialtools/cardutils.py
+++ b/src/Mod/Material/materialtools/cardutils.py
@@ -776,7 +776,7 @@ Units.Quantity(25000, Units.Pressure).getValueAs('MPa')
 Units.Unit('25 MPa')
 Units.Unit(-1,1,-2,0,0,0,0,0)
 
-# base units 
+# base units
 from FreeCAD import Units
 Units.Length
 Units.Mass


### PR DESCRIPTION
This PR should allow to use the Fenics export from the FreeCADCmd interface without relying on an loaded GUI. The necessary dict is inserted via keyword argument into the export function. If it is not provided, it will be filled by default values.

----

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
Different parts of the code report an error like
```
ERROR: testPivy (TestDraft.DraftTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/demon_ds/Programming/git/FreeCAD-FEM/freecad-build/Mod/Draft/TestDraft.py", line 43, in testPivy
    FreeCADGui.ActiveDocument.ActiveView.getSceneGraph().addChild(c)
RuntimeError: No SWIG wrapped library loaded
```
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
