### PR TITLE
name 'QtCore' is not defined

### DIFF
--- a/src/Mod/Fem/femcommands/commands.py
+++ b/src/Mod/Fem/femcommands/commands.py
@@ -22,9 +22,11 @@
 
 import FreeCAD
 import FreeCADGui
+from PySide import QtCore
 
 from .manager import CommandManager
 from femtools.femutils import is_of_type
+
 
 
 # Python command definitions


### PR DESCRIPTION
error when activate FEM WB:

'name 'QtCore' is not defined
Traceback (most recent call last):
  File "<string>", line 43, in Initialize
  File "/home/ebi/freecads/freecad-build/Mod/Fem/femcommands/commands.py", line 942, in <module>
    _SolverOpenSees()
  File "/home/ebi/freecads/freecad-build/Mod/Fem/femcommands/commands.py", line 745, in __init__
    "MenuText": QtCore.QT_TRANSLATE_NOOP(
'

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
