### PR TITLE
FEM: remove superfluous 'pass'

### DIFF
--- a/src/Mod/Fem/femobjects/constraint_sectionprint.py
+++ b/src/Mod/Fem/femobjects/constraint_sectionprint.py
@@ -2,7 +2,7 @@
 # *   Copyright (c) 2020 Bernd Hahnebach <bernd@bimstatik.org>              *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
-
+# *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
 # *   as published by the Free Software Foundation; either version 2 of     *
@@ -41,5 +41,3 @@ class ConstraintSectionPrint(base_fempythonobject.BaseFemPythonObject):
 
     def __init__(self, obj):
         super(ConstraintSectionPrint, self).__init__(obj)
-
-        pass


### PR DESCRIPTION
Fixes LGTM alert. Per the documentation:  
```
A 'pass' statement is only necessary when it is the only statement in a block (the list of statements forming part of a compound statement). This is because the purpose of the 'pass' statement is to allow empty blocks where they would otherwise be syntactically invalid. If the block already contains other statements then the 'pass' statement is unnecessary.
```